### PR TITLE
Add the Mask Variable to the Topo Editor + Rectangle Select

### DIFF
--- a/.docstr/bathymetry/index.rst
+++ b/.docstr/bathymetry/index.rst
@@ -1,0 +1,107 @@
+Bathymetry Workflow
+======================================
+
+The bathymetry workflow pipeline combines multiple components for creating and modifying MOM6 bathymetry files. This section documents the key concepts, operations, and best practices for working with bathymetry in mom6_forge.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Bathymetry Topics:
+
+   mask_depth_calculation
+
+Overview of the Bathymetry Pipeline
+------------------------------------
+
+The mom6_forge bathymetry workflow consists of these key stages:
+
+1. **Grid Creation** — Define the horizontal MOM6 grid
+2. **Depth Initialization** — Load or generate initial bathymetry
+3. **Masking** — Apply ocean/land masks (e.g., from land fraction data)
+4. **Refinement** — Apply ridges, smooth features, or manual edits
+5. **Validation** — Check consistency and apply min/max depth constraints
+6. **Output** — Write final bathymetry to TOPO_FILE
+
+Key Concepts
+------------
+
+**Separation of Concerns**
+
+Raw depth data (``_unmasked_depth``) is kept separate from masking logic (``_mask``). This enables:
+
+- Efficient storage (only one copy of depth data)
+- Flexible masking (masks can be applied/removed without re-computing)
+- Clean version control (edits to depth vs mask are independent)
+
+**Version Control Integration**
+
+All bathymetry modifications are tracked through the TopoCommandManager (TCM):
+
+- Every edit creates a record (index, old_value, new_value)
+- Full undo/redo capability
+- Version history saved to git
+- Can restore any previous bathymetry state
+
+**Minimal Depth Enforcement**
+
+The ``min_depth`` parameter ensures all ocean cells meet a minimum depth for model stability:
+
+- Ocean cells shallower than ``min_depth`` are boosted to ``min_depth + 0.1``
+- Ensures model doesn't attempt to integrate in cells that are too shallow
+- Configurable per-Topo instance
+
+Common Workflows
+----------------
+
+**Workflow 1: Load existing bathymetry with mask**
+
+.. code-block:: python
+
+    # Load bathymetry from file
+    topo = Topo.from_topo_file(grid, "input_topo.nc")
+    
+    # Apply an ocean/land mask
+    topo.apply_land_frac("land_fraction.nc", landfrac_name="LANDFRAC", ...)
+    
+    # Write output
+    topo.write_topo("output_topo.nc")
+
+**Workflow 2: Create idealized bathymetry**
+
+.. code-block:: python
+
+    # Create flat or idealized bathymetry
+    topo = Topo(grid, min_depth=100.0)
+    topo.set_spoon(max_depth=5000.0, dedge=100.0)
+    
+    # Apply custom modifications
+    topo.apply_ridge(height=1000.0, width=10.0, lon=-120.0, ilat=(10, 50))
+    
+    # Output
+    topo.write_topo("idealized_topo.nc")
+
+**Workflow 3: Load and edit interactively**
+
+.. code-block:: python
+
+    # Load existing bathymetry with version control
+    topo = Topo.from_version_control("TopoLibrary/my_domain")
+    
+    # Make edits
+    topo.apply_ridge(...)
+    
+    # Undo if needed
+    topo.tcm.undo()
+    
+    # Save changes
+    topo.save()
+
+Documentation Index
+-------------------
+
+- **Mask and Depth Calculation** — Details on the separation-of-concerns design for depth and masking
+
+Related Documentation
+---------------------
+
+- See the main :doc:`../quickstart` for basic grid and bathymetry setup
+- Check :doc:`../examples` for Jupyter notebook examples

--- a/.docstr/bathymetry/mask_depth_calculation.rst
+++ b/.docstr/bathymetry/mask_depth_calculation.rst
@@ -1,0 +1,149 @@
+Mask and Depth Calculation
+======================================
+
+Overview
+--------
+
+The `Topo` class uses a separation-of-concerns architecture for handling bathymetry depth and ocean/land masking. This ensures clean version control, flexible masking capabilities, and intuitive API design.
+
+Core Components
+---------------
+
+**Raw Depth Storage: ``_unmasked_depth``**
+
+This is the internal storage for the actual bathymetry data as provided by the user or loaded from files. It represents the true water column depths without any masking applied.
+
+.. code-block:: python
+
+    # Internal storage - rarely accessed directly by users
+    topo._unmasked_depth  # xr.DataArray with shape (ny, nx)
+
+**Land/Ocean Mask: ``_mask``**
+
+An optional binary mask indicating which cells are ocean (1) and which are land (0). When ``None``, no masking is applied.
+
+.. code-block:: python
+
+    # Set a binary ocean/land mask
+    topo.mask = ocean_mask  # xr.DataArray or np.ndarray with values 0 or 1
+    
+    # Disable masking
+    topo.mask = None
+
+**Depth Property: ``depth``**
+
+The public interface that applies masking on-the-fly. When no mask is set, it returns ``_unmasked_depth``. When a mask is set, it calculates and returns masked depth values.
+
+.. code-block:: python
+
+    # Read masked or unmasked depth depending on mask state
+    depth_array = topo.depth  # xr.DataArray with masking applied if mask is set
+
+How Masking Works
+------------------
+
+When a mask is set, the `depth` property applies these rules:
+
+1. **Ocean cells** (mask == 1):
+   
+   - Values are preserved if they exceed ``min_depth``
+   - Values below ``min_depth`` are bumped to ``min_depth + 0.1`` to ensure navigability
+   
+2. **Land cells** (mask == 0):
+   
+   - Values are set to ``land_fillval`` (default: 0.0)
+   - This is fully configurable via the ``land_fillval`` property
+
+.. code-block:: python
+
+    # Example: Set custom land fill value
+    topo.land_fillval = -0.5  # Represent dry cells as negative
+    
+    # Now when depth is read, land cells will show -0.5
+    depth = topo.depth  # Ocean cells have real depths, land cells are -0.5
+
+Version Control and Edits
+--------------------------
+
+All depth modifications go through the ``send_entire_depth_change_to_tcm()`` method, which:
+
+- Modifies only ``_unmasked_depth`` (the raw storage)
+- Preserves the existing mask
+- Records changes in the TopoCommandManager (TCM) for undo/redo support
+- Allows full version control of bathymetry edits
+
+.. code-block:: python
+
+    # When you modify depth, the mask is preserved
+    topo.depth = new_depth_array  # Only _unmasked_depth is updated
+    
+    # The mask remains intact
+    assert topo.mask == original_mask
+
+Practical Example
+-----------------
+
+Setting up bathymetry with masking:
+
+.. code-block:: python
+
+    from mom6_forge.grid import Grid
+    from mom6_forge.topo import Topo
+    import numpy as np
+
+    # Create grid and topo
+    grid = Grid(nx=180, ny=90, lenx=360.0, leny=180.0)
+    topo = Topo(grid, min_depth=100.0)
+    
+    # Set flat bathymetry
+    topo.set_flat(5000.0)
+    
+    # Create a simple ocean/land mask (1 = ocean, 0 = land)
+    mask = np.ones((grid.ny, grid.nx), dtype=int)
+    mask[:, :40] = 0  # Western region is land
+    
+    # Apply the mask
+    topo.mask = mask
+    
+    # Now when you read depth:
+    # - Western cells (land) → 0.0 (or custom land_fillval)
+    # - Eastern cells (ocean) → 5000.0 (or bumped to min_depth if shallower)
+    depth = topo.depth
+    
+    # Configure land fill value
+    topo.land_fillval = -100.0
+    depth = topo.depth  # Now land cells show -100.0
+
+API Reference
+-------------
+
+**Properties:**
+
+- ``topo.depth`` — Get/set the depth array (applies masking when reading if mask is set)
+- ``topo.mask`` — Get/set the binary ocean/land mask
+- ``topo.land_fillval`` — Get/set the depth value for land cells (default: 0.0)
+- ``topo.min_depth`` — Get/set the minimum ocean depth threshold
+
+**Methods:**
+
+- ``topo.apply_land_frac(...)`` — Generate and apply ocean mask from land fraction data
+- ``topo.send_entire_depth_change_to_tcm(depth)`` — Apply a full depth array update with version control
+
+**Internal:**
+
+- ``topo._unmasked_depth`` — Raw depth storage (use ``topo.depth`` instead)
+- ``topo._mask`` — Internal mask storage (use ``topo.mask`` instead)
+- ``topo._land_fillval`` — Internal land fill value storage (use ``topo.land_fillval`` instead)
+
+Benefits of This Design
+-----------------------
+
+✓ **Clean separation** — Raw data separate from masking logic
+
+✓ **Full version control** — All edits tracked in TCM without bloating the history with mask applications
+
+✓ **Flexible masking** — Mask can be applied, modified, or removed without affecting stored bathymetry
+
+✓ **Efficient computation** — Masking applied on-read rather than stored, reducing file size
+
+✓ **Intuitive API** — Users work with ``depth`` and ``mask`` properties; internal storage is hidden

--- a/.docstr/bathymetry/mask_depth_calculation.rst
+++ b/.docstr/bathymetry/mask_depth_calculation.rst
@@ -9,47 +9,59 @@ The `Topo` class uses a separation-of-concerns architecture for handling bathyme
 Core Components
 ---------------
 
-**Raw Depth Storage: ``_unmasked_depth``**
+**Raw Depth Storage: ``_depth_raw``**
 
-This is the internal storage for the actual bathymetry data as provided by the user or loaded from files. It represents the true water column depths without any masking applied.
+This is the internal storage for the actual bathymetry data as provided by the user or loaded from files. It represents the true water column depths without any masking applied. Access via the ``depth_raw`` property.
 
 .. code-block:: python
 
-    # Internal storage - rarely accessed directly by users
-    topo._unmasked_depth  # xr.DataArray with shape (ny, nx)
+    # Read raw depth
+    raw_depth = topo.depth_raw  # xr.DataArray with shape (ny, nx)
+    
+    # Set raw depth (preserves any existing manual mask)
+    topo.depth_raw = new_bathymetry
 
-**Land/Ocean Mask: ``_mask``**
+**Manual Ocean/Land Mask: ``_manual_mask``**
 
-An optional binary mask indicating which cells are ocean (1) and which are land (0). When ``None``, no masking is applied.
+An optional binary mask indicating which cells are ocean (1) and which are land (0). When ``None``, no manual masking is applied. The mask is automatically enforced: ocean cells have min_depth enforcement, land cells receive the ``land_fillval``.
 
 .. code-block:: python
 
     # Set a binary ocean/land mask
     topo.mask = ocean_mask  # xr.DataArray or np.ndarray with values 0 or 1
     
-    # Disable masking
+    # Disable manual masking
     topo.mask = None
 
 **Depth Property: ``depth``**
 
-The public interface that applies masking on-the-fly. When no mask is set, it returns ``_unmasked_depth``. When a mask is set, it calculates and returns masked depth values.
+The public interface that applies masking on-the-fly. When no manual mask is set, it returns ``_depth_raw``. When a manual mask is set, it calculates and returns masked depth values.
 
 .. code-block:: python
 
-    # Read masked or unmasked depth depending on mask state
+    # Read masked or raw depth depending on manual mask state
     depth_array = topo.depth  # xr.DataArray with masking applied if mask is set
+
+**Land Cell Fill Value: ``land_fillval``**
+
+Configurable depth value assigned to land cells when a manual mask is applied. Default is ``0.0`` (dry). Must be ``<= min_depth`` to prevent land cells from being treated as ocean.
+
+.. code-block:: python
+
+    topo.land_fillval = 0.0  # Set all land cells to 0.0 m (default)
+    topo.land_fillval = -100.0  # Or use negative values for special meaning
 
 How Masking Works
 ------------------
 
-When a mask is set, the `depth` property applies these rules:
+When a manual mask is set, the `depth` property applies these rules:
 
-1. **Ocean cells** (mask == 1):
+1. **Ocean cells** (manual_mask == 1):
    
    - Values are preserved if they exceed ``min_depth``
    - Values below ``min_depth`` are bumped to ``min_depth + 0.1`` to ensure navigability
    
-2. **Land cells** (mask == 0):
+2. **Land cells** (manual_mask == 0):
    
    - Values are set to ``land_fillval`` (default: 0.0)
    - This is fully configurable via the ``land_fillval`` property
@@ -62,23 +74,88 @@ When a mask is set, the `depth` property applies these rules:
     # Now when depth is read, land cells will show -0.5
     depth = topo.depth  # Ocean cells have real depths, land cells are -0.5
 
+Usage Examples
+--------------
+
+**Setup with Manual Masking**
+
+.. code-block:: python
+
+    from mom6_forge.topo import Topo
+    
+    # Create Topo object with initial bathymetry
+    topo = Topo(depth=my_depth_array)
+    
+    # Apply ocean/land mask
+    topo.mask = ocean_mask  # Binary mask, shape (ny, nx)
+    
+    # Configure land cell behavior
+    topo.land_fillval = 0.0  # Land cells set to 0.0 m
+    
+    # Access masked depth values
+    masked_depth = topo.depth
+    print(f"Ocean cells averaged: {topo.depth.where(ocean_mask).mean()}")
+    print(f"Land cells: {topo.depth.where(~ocean_mask.astype(bool)).unique()}")
+
+**Disable Masking**
+
+.. code-block:: python
+
+    # Revert to unmasked raw depths
+    topo.mask = None
+    raw_depth = topo.depth  # Now returns _depth_raw unchanged
+
+**Check Raw vs Masked**
+
+.. code-block:: python
+
+    # Compare raw and masked versions
+    raw = topo.depth_raw
+    masked = topo.depth
+    
+    if topo.mask is not None:
+        diff = (masked - raw).sum()
+        print(f"Masking applied - differences in {(masked != raw).sum()} cells")
+
 Version Control and Edits
 --------------------------
 
 All depth modifications go through the ``send_entire_depth_change_to_tcm()`` method, which:
 
-- Modifies only ``_unmasked_depth`` (the raw storage)
-- Preserves the existing mask
+- Modifies only ``_depth_raw`` (the raw storage)
+- Preserves the existing manual mask
 - Records changes in the TopoCommandManager (TCM) for undo/redo support
 - Allows full version control of bathymetry edits
 
 .. code-block:: python
 
-    # When you modify depth, the mask is preserved
-    topo.depth = new_depth_array  # Only _unmasked_depth is updated
+    # When you modify depth, the manual mask is preserved
+    topo.depth = new_depth_array  # Only _depth_raw is updated
     
-    # The mask remains intact
+    # The manual mask remains intact
     assert topo.mask == original_mask
+
+Internal Architecture
+---------------------
+
+.. code-block:: text
+
+    User sets: topo.mask = ocean_mask
+                ↓
+    Stored in: self._manual_mask
+                ↓
+            When user calls: topo.depth
+                ↓
+            Property checks: if self._manual_mask is not None
+                ↓
+            If mask exists:
+                Calculate: masked_depth = where(mask==1, enforce_min_depth(_depth_raw),
+                                                           land_fillval)
+                ↓
+            If no mask:
+                Return: self._depth_raw directly
+                ↓
+            Return: masked/raw depth array
 
 Practical Example
 -----------------
@@ -131,9 +208,9 @@ API Reference
 
 **Internal:**
 
-- ``topo._unmasked_depth`` — Raw depth storage (use ``topo.depth`` instead)
-- ``topo._mask`` — Internal mask storage (use ``topo.mask`` instead)
-- ``topo._land_fillval`` — Internal land fill value storage (use ``topo.land_fillval`` instead)
+- ``topo._depth_raw`` — Raw depth storage (use ``topo.depth_raw`` property or ``topo.depth`` instead)
+- ``topo._manual_mask`` — Internal manual mask storage (use ``topo.mask`` property instead)
+- ``topo._land_fillval`` — Internal land fill value storage (use ``topo.land_fillval`` property instead)
 
 Benefits of This Design
 -----------------------

--- a/.docstr/index.rst
+++ b/.docstr/index.rst
@@ -16,6 +16,7 @@ to learn about the `mom6_forge` tool.
 
    installation
    quickstart
+   bathymetry/index
    examples
    glossary
    widgets

--- a/mom6_forge/edit_command.py
+++ b/mom6_forge/edit_command.py
@@ -82,10 +82,10 @@ class DepthEditCommand(EditCommand):
         self.message = message
 
     def _get_value(self, j, i):
-        return self._topo.depth.data[j, i]
+        return self._topo._unmasked_depth.data[j, i]
 
     def _set_value(self, j, i, value):
-        self._topo.depth.data[j, i] = value
+        self._topo._unmasked_depth.data[j, i] = value
 
     def __call__(self):
         if self.old_values is None:

--- a/mom6_forge/edit_command.py
+++ b/mom6_forge/edit_command.py
@@ -1,4 +1,5 @@
 import numpy as np
+import xarray as xr
 from abc import ABC, abstractmethod
 
 
@@ -82,12 +83,85 @@ class DepthEditCommand(EditCommand):
         self.message = message
 
     def _get_value(self, j, i):
-        return self._topo._unmasked_depth.data[j, i]
+        return self._topo._depth_raw.data[j, i]
 
     def _set_value(self, j, i, value):
-        self._topo._unmasked_depth.data[j, i] = value
+        self._topo._depth_raw.data[j, i] = value
 
     def __call__(self):
+        if self.old_values is None:
+            self.old_values = [
+                to_native(self._get_value(j, i)) for j, i in self.affected_indices
+            ]
+        for idx, (j, i) in enumerate(self.affected_indices):
+            self._set_value(j, i, self.new_values[idx])
+
+    def serialize(self):
+        return {
+            "type": self.__class__.__name__,
+            "affected_indices": [to_native_tuple(idx) for idx in self.affected_indices],
+            "new_values": [to_native(v) for v in self.new_values],
+            "old_values": (
+                [to_native(v) for v in self.old_values]
+                if self.old_values is not None
+                else None
+            ),
+        }
+
+    @classmethod
+    def deserialize(cls, data):
+        return lambda topo: cls(
+            topo,
+            affected_indices=[tuple(idx) for idx in data["affected_indices"]],
+            new_values=data["new_values"],
+            old_values=data["old_values"],
+        )
+
+    @classmethod
+    def reverse_deserialize(cls, data):
+        return lambda topo: cls(
+            topo,
+            affected_indices=[tuple(idx) for idx in data["affected_indices"]],
+            new_values=data["old_values"],
+            old_values=data["new_values"],
+        )
+
+
+@register_command
+class MaskEditCommand(EditCommand):
+    """Define any edit that affects one or more elements of the binary ocean/land mask array"""
+
+    def __init__(
+        self, topo, affected_indices, new_values, old_values=None, message="Mask Edit"
+    ):
+        self._topo = topo
+        # Convert indices and values to native types for consistency and serialization
+        self.affected_indices = [to_native_tuple(idx) for idx in affected_indices]
+        self.new_values = [to_native(v) for v in new_values]
+        self.old_values = (
+            [to_native(v) for v in old_values] if old_values is not None else None
+        )
+        self.message = message
+
+    def _get_value(self, j, i):
+        return self._topo.mask.data[j, i]
+
+    def _set_value(self, j, i, value):
+        """
+        Set the mask value at the specified indices.
+        The value must be binary (0 for land, 1 for ocean)."""
+
+        # Validate binary value
+        assert value in [0, 1], f"Mask value must be 0 (land) or 1 (ocean), got {value}"
+        self._topo._manual_mask.data[j, i] = value
+
+    def __call__(self):
+        """If the manual mask is not initialized, it will be created from the depth raw mask, because at this point we are creating a mask."""
+        if self._topo._manual_mask is None:
+            print(
+                "The manual mask is not initialized. Initializing it now from the depth raw mask"
+            )
+            self._topo._manual_mask = self._topo._depth_raw_mask.copy()
         if self.old_values is None:
             self.old_values = [
                 to_native(self._get_value(j, i)) for j, i in self.affected_indices
@@ -167,3 +241,64 @@ class MinDepthEditCommand(EditCommand):
             new_value=data["old_value"],
             old_value=data["new_value"],
         )
+
+
+@register_command
+class ClearMaskCommand(EditCommand):
+    """Clears the manual mask, reverting to depth_raw_mask derived mask."""
+
+    def __init__(self, topo, old_mask=None, message="Clear Manual Mask"):
+        self._topo = topo
+        self.old_mask = old_mask
+        self.message = message
+
+    def __call__(self):
+        if self.old_mask is None:
+            self.old_mask = self._topo._manual_mask  # snapshot for undo
+        self._topo._manual_mask = None
+
+    def serialize(self):
+        return {
+            "type": self.__class__.__name__,
+            "old_mask": (
+                self.old_mask.values.tolist() if self.old_mask is not None else None
+            ),
+        }
+
+    @classmethod
+    def deserialize(cls, data):
+        def factory(topo):
+            old_mask = data["old_mask"]
+            if old_mask is not None:
+                old_mask = xr.DataArray(
+                    np.array(old_mask),
+                    dims=["ny", "nx"],
+                    attrs={"name": "binary ocean/land mask"},
+                )
+            return cls(topo, old_mask=old_mask)
+
+        return factory
+
+    @classmethod
+    def reverse_deserialize(cls, data):
+        """Undo a clear by restoring the old mask via MaskEditCommand."""
+
+        def factory(topo):
+            old_mask = data["old_mask"]
+            if old_mask is None:
+                return cls(topo)  # was already None, just clear again
+            mask_array = np.array(old_mask)
+            all_indices = list(np.ndindex(mask_array.shape))
+            new_values = mask_array.ravel().tolist()
+            old_values = [0] * len(
+                new_values
+            )  # placeholder, will be overwritten on __call__
+            return MaskEditCommand(
+                topo,
+                all_indices,
+                new_values,
+                old_values=old_values,
+                message="Restore mask (undo clear)",
+            )
+
+        return factory

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -158,6 +158,18 @@ class Topo:
         )
         return masked_depth
 
+    @property.setter
+    def depth(self, depth):
+        """
+        Set the depth by directly assigning to the depth property. This is a wrapper around setting depth_raw.
+
+        Parameters
+        ----------
+        depth: np.array or xr.DataArray
+            2-D Array of ocean depth (m).
+        """
+        self.depth_raw = depth  # Use the depth_raw setter
+
     @property
     def depth_raw(self):
         """

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -267,10 +267,7 @@ class Topo:
             Binary mask (1=ocean, 0=land) with shape (ny, nx), or None to disable masking.
         """
         if new_mask is None:
-            cmd = ClearMaskCommand(
-                self, message="Clear manual mask"
-            )  # Resets back to reading from depth
-            self.tcm.execute(cmd, cmd_type=CommandType.COMMAND)
+            self.clear_manual_mask()  # Clear the manual mask if None is passed
             return
 
         if isinstance(new_mask, xr.DataArray):
@@ -448,6 +445,12 @@ class Topo:
         supergridmask[1::2, ::2] = self.umask.values
         supergridmask[1::2, 1::2] = self.tmask.values
         return supergridmask
+
+    def clear_manual_mask(self):
+        cmd = ClearMaskCommand(
+            self, message="Clear manual mask"
+        )  # Resets back to reading from depth
+        self.tcm.execute(cmd, cmd_type=CommandType.COMMAND)
 
     def point_is_ocean(self, lons, lats):
         """

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -158,7 +158,7 @@ class Topo:
         )
         return masked_depth
 
-    @property.setter
+    @depth.setter
     def depth(self, depth):
         """
         Set the depth by directly assigning to the depth property. This is a wrapper around setting depth_raw.

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -1,7 +1,9 @@
 import os
 import numpy as np
 import xarray as xr
+import xesmf as xe
 from datetime import datetime
+from typing import Optional
 from scipy import interpolate
 from scipy.ndimage import label, binary_fill_holes
 from scipy.spatial import cKDTree
@@ -32,12 +34,16 @@ class Topo:
         """
 
         self._grid = grid
-        self._depth = xr.DataArray(
+        self._unmasked_depth = xr.DataArray(
             np.full((grid.ny, grid.nx), np.nan, dtype=float),
             dims=["ny", "nx"],
             attrs={"units": "m"},
-        )  # Initialize depth with NaNs
+        )  # Initialize unmasked depth with NaNs
+        self._mask: Optional[xr.DataArray] = (
+            None  # Binary ocean/land mask (None = no mask applied)
+        )
         self._min_depth = min_depth
+        self.land_fillval = 0.0  # Depth value for land cells
 
         if version_control_dir is None:
             raise ValueError(
@@ -131,18 +137,36 @@ class Topo:
     def depth(self):
         """
         MOM6 grid depth array (m). Positive below MSL.
+
+        When mask is set, returns masked depth: ocean cells ≥ min_depth+0.1, land cells set to land_fillval.
+        When mask is None, returns raw unmasked depth.
         """
-        return self._depth
+        if self._mask is None:
+            return self._unmasked_depth
+
+        # Apply masking: ocean cells stay as-is (or bump ≥ min_depth+0.1), land cells → land_fillval
+        masked_depth = self._unmasked_depth.copy()
+        ocean_mask = self._mask > 0  # 1 → True (ocean), 0 → False (land)
+
+        # Enforce minimum depth criteria for ocean cells: if depth ≤ min_depth and mask is ocean, set to min_depth + 0.1 to ensure they are still treated as ocean. If mask is land and depth > min_depth, set to land_fillval to ensure they are treated as land.
+        masked_depth = xr.where(
+            ocean_mask,
+            xr.where(
+                masked_depth > self._min_depth, masked_depth, self._min_depth + 0.1
+            ),
+            self._land_fillval,  # Land cells → land_fillval
+        )
+        return masked_depth
 
     @depth.setter
     def depth(self, depth):
         """
-        Apply a custom bathymetry via a user-defined depth array.
+        Modify unmasked depth. Preserves existing mask.
 
         Parameters
         ----------
-        depth: np.array
-            2-D Array of ocean depth (m).
+        depth: np.array or xr.DataArray or scalar
+            2-D Array of ocean depth (m), or scalar depth for flat bathymetry.
         """
 
         if np.isscalar(depth):
@@ -161,7 +185,7 @@ class Topo:
                 depth, np.ndarray
             ), "depth must be a numpy array or xarray DataArray"
 
-        self._depth = xr.DataArray(
+        self._unmasked_depth = xr.DataArray(
             depth,
             dims=["ny", "nx"],
             attrs={"units": "m"},
@@ -186,12 +210,69 @@ class Topo:
         self._min_depth = new_min_depth
 
     @property
+    def land_fillval(self):
+        """
+        Depth value assigned to land cells when mask is applied. Default is 0.0 (dry).
+        """
+        return self._land_fillval
+
+    @land_fillval.setter
+    def land_fillval(self, new_land_fillval):
+        assert isinstance(
+            new_land_fillval, (int, float)
+        ), "land_fillval must be a number"
+        assert (
+            new_land_fillval <= self._min_depth
+        ), "land_fillval should be less than or equal to min_depth to ensure land cells are not mistakenly treated as ocean"
+        self._land_fillval = float(new_land_fillval)
+
+    @property
+    def mask(self):
+        """
+        Optional binary ocean/land mask. 1 if ocean, 0 if land.
+        When set, the depth property applies masking: ocean cells enforced ≥ min_depth+0.1, land cells set to land_fillval.
+        """
+        return self._mask
+
+    @mask.setter
+    def mask(self, new_mask):
+        """
+        Set the binary ocean/land mask.
+
+        Parameters
+        ----------
+        new_mask: xr.DataArray or np.ndarray or None
+            Binary mask (1=ocean, 0=land) with shape (ny, nx), or None to disable masking.
+        """
+        if new_mask is None:
+            self._mask = None
+            return
+
+        if isinstance(new_mask, xr.DataArray):
+            new_mask = new_mask.data
+        else:
+            assert isinstance(
+                new_mask, np.ndarray
+            ), "mask must be a numpy array, xarray DataArray, or None"
+
+        assert new_mask.shape == (
+            self._grid.ny,
+            self._grid.nx,
+        ), "Incompatible mask shape"
+
+        self._mask = xr.DataArray(
+            new_mask,
+            dims=["ny", "nx"],
+            attrs={"name": "binary ocean/land mask"},
+        )
+
+    @property
     def tmask(self):
         """
         Ocean domain mask at T grid. 1 if ocean, 0 if land.
         """
         tmask_da = xr.DataArray(
-            np.where(self._depth > self._min_depth, 1, 0),
+            np.where(self.depth > self._min_depth, 1, 0),
             dims=["ny", "nx"],
             attrs={"name": "T mask"},
         )
@@ -331,16 +412,21 @@ class Topo:
     def send_entire_depth_change_to_tcm(self, depth, quietly=False):
         """
         This function takes an entire depth change and adds it through the TopoCommandManager (TCM) or directly if quietly is enabled.
+        Modifies _unmasked_depth, preserves mask.
         """
         # 1. Generate all affected indices (row-major order)
-        all_indices = list(np.ndindex(self.depth.shape))  # list of (j, i) tuples
+        all_indices = list(
+            np.ndindex(self._unmasked_depth.shape)
+        )  # list of (j, i) tuples
 
         # 2. Flatten the new values to match the indices
         new_values = depth.values.ravel().tolist()
 
-        # 3. Flatten old values if depth exists
+        # 3. Flatten old values from unmasked_depth
         old_values = (
-            self.depth.values.ravel().tolist() if self.depth is not None else None
+            self._unmasked_depth.values.ravel().tolist()
+            if self._unmasked_depth is not None
+            else None
         )
 
         # 4. Build command
@@ -1106,8 +1192,8 @@ class Topo:
         new_vals = []
         for j in range(ilat[0], ilat[1]):
             affected_indices.extend([(j, i) for i in range(self._grid.nx)])
-            old_vals.extend(self._depth[j, :].values)
-            new_vals.extend((self._depth[j, :] + ridge_height_mapped).values)
+            old_vals.extend(self.depth[j, :].values)
+            new_vals.extend((self.depth[j, :] + ridge_height_mapped).values)
         depth_edit_command = DepthEditCommand(
             self, affected_indices, new_vals, old_values=old_vals
         )
@@ -1119,7 +1205,6 @@ class Topo:
         landfrac_name,
         xcoord_name,
         ycoord_name,
-        depth_fillval=0.0,
         cutoff_frac=0.5,
         method="bilinear",
     ):
@@ -1136,15 +1221,11 @@ class Topo:
             The name of the x coordinate of the landfrac dataset (e.g., "lon").
         ycoord_name : str
             The name of the y coordinate of the landfrac dataset (e.g., "lat").
-        depth_fillval : float
-            The depth value for dry cells.
         cutoff_frac : float
             Cells with landfrac > cutoff_frac are deemed land cells.
         method : str
             Mapping method for determining the ocean mask (lnd -> ocn)
         """
-
-        import xesmf as xe
 
         assert isinstance(landfrac_filepath, str), "landfrac_filepath must be a string"
         assert landfrac_filepath.endswith(
@@ -1165,17 +1246,11 @@ class Topo:
             landfrac_name in ds
         ), f"Couldn't find {ycoord_name} in {landfrac_filepath}"
         assert isinstance(
-            depth_fillval, float
-        ), f"depth_fillval={depth_fillval} must be a float"
-        assert (
-            depth_fillval < self._min_depth
-        ), f"depth_fillval (the depth of dry cells) must be smaller than the minimum depth {self._min_depth}"
-        assert isinstance(
             cutoff_frac, float
         ), f"cutoff_frac={cutoff_frac} must be a float"
         assert (
             0.0 <= cutoff_frac <= 1.0
-        ), f"cutoff_frac={cutoff_frac} must be 0<= and <=1"
+        ), f"cutoff_frac={cutoff_frac} must be between 0 and 1"
 
         valid_methods = [
             "bilinear",
@@ -1196,26 +1271,11 @@ class Topo:
         regridder = xe.Regridder(ds, ds_mapped, method, periodic=self._grid.is_cyclic_x)
         mask_mapped = regridder(ds.landfrac)
 
-        # Build TCM Object - This is not the entire depth change, just the cells to be filled
-        mask = mask_mapped > cutoff_frac  # boolean mask
-        ny, nx = self._depth.shape
+        # Convert land fraction to binary mask (1=ocean, 0=land)
+        binary_mask = (mask_mapped <= cutoff_frac).astype(int)
+        self.mask = binary_mask  # Set via mask property
 
-        affected_indices = []
-        old_vals = []
-        new_vals = []
-
-        for j in range(ny):
-            for i in range(nx):
-
-                if mask[j, i]:
-                    affected_indices.append((j, i))
-                    old_vals.append(float(self._depth[j, i]))  # extract scalar here
-                    new_vals.append(float(depth_fillval))  # and here
-
-        depth_edit_command = DepthEditCommand(
-            self, affected_indices, new_vals, old_values=old_vals
-        )
-        self.tcm.execute(depth_edit_command)
+        # legacy code set the depth of land cells to depth_fillval, but now that is handled in the depth property.
 
     def gen_topo_ds(self, title=None):
         """
@@ -1264,8 +1324,9 @@ class Topo:
             },
         )
 
+        # Write masked depth (from property) to file
         ds["depth"] = xr.DataArray(
-            self._depth.data,
+            self.depth.data,
             dims=["ny", "nx"],
             attrs={"long_name": "t-grid cell depth", "units": "m"},
         )

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -1316,12 +1316,19 @@ class Topo:
         )
 
         ds["mask"] = xr.DataArray(
-            self.tmask.astype(np.int32),
+            self.mask.astype(np.int32),
             dims=["ny", "nx"],
             attrs={
                 "long_name": "landsea mask at t points: 1 ocean, 0 land",
                 "units": "nondim",
             },
+        )
+
+        # Write unmasked depth to file
+        ds["unmasked_depth"] = xr.DataArray(
+            self._unmasked_depth.data,
+            dims=["ny", "nx"],
+            attrs={"long_name": "t-grid cell depth", "units": "m"},
         )
 
         # Write masked depth (from property) to file

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -1387,9 +1387,8 @@ class Topo:
             },
         )
 
-        # tmask is calculated from the depth, which is calculated from the unmasked_depth + mask, so we're preserving the mask here! Don't worry!
         ds["mask"] = xr.DataArray(
-            self.tmask.astype(np.int32),
+            self.mask.astype(np.int32),
             dims=["ny", "nx"],
             attrs={
                 "long_name": "landsea mask at t points: 1 ocean, 0 land",

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -1315,8 +1315,9 @@ class Topo:
             },
         )
 
+        # tmask is calculated from the depth, which is calculated from the unmasked_depth + mask, so we're preserving the mask here! Don't worry!
         ds["mask"] = xr.DataArray(
-            self.mask.astype(np.int32),
+            self.tmask.astype(np.int32),
             dims=["ny", "nx"],
             attrs={
                 "long_name": "landsea mask at t points: 1 ocean, 0 land",

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -247,6 +247,11 @@ class Topo:
         When set, the depth property applies masking: ocean cells enforced ≥ min_depth+0.1, land cells set to land_fillval.
         """
         if self._manual_mask is None:
+            if self._depth_raw is None:
+                # If depth_raw is not set, return None for mask
+                raise ValueError(
+                    "Raw Depth (_depth_raw) is not set and Manual Mask is not set (_manual_mask), so mask is undefined. Please set depth_raw or set a manual mask."
+                )
             return self._depth_raw_mask
         else:
             return self._manual_mask

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -34,12 +34,12 @@ class Topo:
         """
 
         self._grid = grid
-        self._unmasked_depth = xr.DataArray(
+        self._depth_raw = xr.DataArray(
             np.full((grid.ny, grid.nx), np.nan, dtype=float),
             dims=["ny", "nx"],
             attrs={"units": "m"},
-        )  # Initialize unmasked depth with NaNs
-        self._mask: Optional[xr.DataArray] = (
+        )  # Initialize raw depth with NaNs
+        self._manual_mask: Optional[xr.DataArray] = (
             None  # Binary ocean/land mask (None = no mask applied)
         )
         self._min_depth = min_depth
@@ -139,14 +139,14 @@ class Topo:
         MOM6 grid depth array (m). Positive below MSL.
 
         When mask is set, returns masked depth: ocean cells ≥ min_depth+0.1, land cells set to land_fillval.
-        When mask is None, returns raw unmasked depth.
+        When mask is None, returns raw depth.
         """
-        if self._mask is None:
-            return self._unmasked_depth
+        if self._manual_mask is None:
+            return self._depth_raw
 
         # Apply masking: ocean cells stay as-is (or bump ≥ min_depth+0.1), land cells → land_fillval
-        masked_depth = self._unmasked_depth.copy()
-        ocean_mask = self._mask > 0  # 1 → True (ocean), 0 → False (land)
+        masked_depth = self._depth_raw.copy()
+        ocean_mask = self._manual_mask > 0  # 1 → True (ocean), 0 → False (land)
 
         # Enforce minimum depth criteria for ocean cells: if depth ≤ min_depth and mask is ocean, set to min_depth + 0.1 to ensure they are still treated as ocean. If mask is land and depth > min_depth, set to land_fillval to ensure they are treated as land.
         masked_depth = xr.where(
@@ -158,34 +158,36 @@ class Topo:
         )
         return masked_depth
 
-    @depth.setter
-    def depth(self, depth):
+    @property
+    def depth_raw(self):
         """
-        Modify unmasked depth. Preserves existing mask.
+        Raw depth array before masking is applied.
+        """
+        return self._depth_raw
+
+    @depth_raw.setter
+    def depth_raw(self, depth):
+        """
+        Set raw depth array. Preserves existing mask.
 
         Parameters
         ----------
-        depth: np.array or xr.DataArray or scalar
-            2-D Array of ocean depth (m), or scalar depth for flat bathymetry.
+        depth: np.array or xr.DataArray
+            2-D Array of ocean depth (m).
         """
-
-        if np.isscalar(depth):
-            self.set_flat(depth)
-            return
+        if isinstance(depth, xr.DataArray):
+            depth = depth.data
+        else:
+            assert isinstance(
+                depth, np.ndarray
+            ), "depth_raw must be a numpy array or xarray DataArray"
 
         assert depth.shape == (
             self._grid.ny,
             self._grid.nx,
         ), "Incompatible depth array shape"
 
-        if isinstance(depth, xr.DataArray):
-            depth = depth.data
-        else:
-            assert isinstance(
-                depth, np.ndarray
-            ), "depth must be a numpy array or xarray DataArray"
-
-        self._unmasked_depth = xr.DataArray(
+        self._depth_raw = xr.DataArray(
             depth,
             dims=["ny", "nx"],
             attrs={"units": "m"},
@@ -232,7 +234,10 @@ class Topo:
         Optional binary ocean/land mask. 1 if ocean, 0 if land.
         When set, the depth property applies masking: ocean cells enforced ≥ min_depth+0.1, land cells set to land_fillval.
         """
-        return self._mask
+        if self._manual_mask is None:
+            return self._depth_raw_mask
+        else:
+            return self._manual_mask
 
     @mask.setter
     def mask(self, new_mask):
@@ -245,7 +250,10 @@ class Topo:
             Binary mask (1=ocean, 0=land) with shape (ny, nx), or None to disable masking.
         """
         if new_mask is None:
-            self._mask = None
+            cmd = ClearMaskCommand(
+                self, message="Clear manual mask"
+            )  # Resets back to reading from depth
+            self.tcm.execute(cmd, cmd_type=CommandType.COMMAND)
             return
 
         if isinstance(new_mask, xr.DataArray):
@@ -260,16 +268,33 @@ class Topo:
             self._grid.nx,
         ), "Incompatible mask shape"
 
-        self._mask = xr.DataArray(
-            new_mask,
-            dims=["ny", "nx"],
-            attrs={"name": "binary ocean/land mask"},
+        all_indices = list(np.ndindex(new_mask.shape))
+        new_values = new_mask.ravel().tolist()
+        old_values = (
+            self.mask.values.ravel().tolist()
+        )  # effective mask (manual or depth_raw_mask)
+
+        cmd = MaskEditCommand(
+            self, all_indices, new_values, old_values=old_values, message="Set mask"
         )
+        self.tcm.execute(cmd, cmd_type=CommandType.COMMAND)
 
     @property
     def tmask(self):
         """
         Ocean domain mask at T grid. 1 if ocean, 0 if land.
+
+        This is a derived mask computed from the depth property. The computation depends on whether
+        a manual mask has been set:
+
+        - If _manual_mask is None: Returns a mask derived from raw depth (_depth_raw).
+          Cells with depth > min_depth are marked as ocean (1), otherwise land (0).
+        - If _manual_mask is set: Returns a mask derived from the masked depth (which applies
+          the manual_mask to _depth_raw). Ocean cells are those with depth > min_depth and
+          manual_mask == 1.
+
+        This design means tmask is always consistent with the current depth state, whether
+        driven by raw bathymetry or by a manually applied mask.
         """
         tmask_da = xr.DataArray(
             np.where(self.depth > self._min_depth, 1, 0),
@@ -277,6 +302,21 @@ class Topo:
             attrs={"name": "T mask"},
         )
         return tmask_da
+
+    @property
+    def _depth_raw_mask(self):
+        """
+        Derived mask computed from raw depth only, ignoring any manual mask.
+
+        This is useful for understanding the ocean/land structure of the raw bathymetry
+        independent of any manually applied mask, but is functionally the same as tmask when no manual mask is set.
+        """
+        depth_raw_mask_da = xr.DataArray(
+            np.where(self._depth_raw > self._min_depth, 1, 0),
+            dims=["ny", "nx"],
+            attrs={"name": "T mask from raw depth"},
+        )
+        return depth_raw_mask_da
 
     @property
     def umask(self):
@@ -412,20 +452,18 @@ class Topo:
     def send_entire_depth_change_to_tcm(self, depth, quietly=False):
         """
         This function takes an entire depth change and adds it through the TopoCommandManager (TCM) or directly if quietly is enabled.
-        Modifies _unmasked_depth, preserves mask.
+        Modifies _depth_raw, preserves mask.
         """
         # 1. Generate all affected indices (row-major order)
-        all_indices = list(
-            np.ndindex(self._unmasked_depth.shape)
-        )  # list of (j, i) tuples
+        all_indices = list(np.ndindex(self._depth_raw.shape))  # list of (j, i) tuples
 
         # 2. Flatten the new values to match the indices
         new_values = depth.values.ravel().tolist()
 
-        # 3. Flatten old values from unmasked_depth
+        # 3. Flatten old values from raw depth
         old_values = (
-            self._unmasked_depth.values.ravel().tolist()
-            if self._unmasked_depth is not None
+            self._depth_raw.values.ravel().tolist()
+            if self._depth_raw is not None
             else None
         )
 
@@ -1142,9 +1180,9 @@ class Topo:
         indices = list(zip(affected[0], affected[1]))
         if not indices:
             return
-        old_values = [self.depth.data[jj, ii] for jj, ii in indices]
+        old_values = [self.mask.data[jj, ii] for jj, ii in indices]
         new_values = [0] * len(indices)
-        cmd = DepthEditCommand(self, indices, new_values, old_values=old_values)
+        cmd = MaskEditCommand(self, indices, new_values, old_values=old_values)
         self.tcm.execute(cmd)
 
     def erase_disconnected_basin(self, i, j):
@@ -1153,9 +1191,9 @@ class Topo:
         indices = list(zip(affected[0], affected[1]))
         if not indices:
             return
-        old_values = [self.depth.data[jj, ii] for jj, ii in indices]
+        old_values = [self.mask.data[jj, ii] for jj, ii in indices]
         new_values = [0] * len(indices)
-        cmd = DepthEditCommand(self, indices, new_values, old_values=old_values)
+        cmd = MaskEditCommand(self, indices, new_values, old_values=old_values)
         self.tcm.execute(cmd)
 
     def apply_ridge(self, height, width, lon, ilat):
@@ -1273,7 +1311,29 @@ class Topo:
 
         # Convert land fraction to binary mask (1=ocean, 0=land)
         binary_mask = (mask_mapped <= cutoff_frac).astype(int)
-        self.mask = binary_mask  # Set via mask property
+
+        # Use MaskEditCommand for version-controlled mask application
+        # Generate all affected indices
+        all_indices = list(np.ndindex(binary_mask.shape))  # list of (j, i) tuples
+        new_values = binary_mask.values.ravel().tolist()
+
+        # Get old values (current mask or 0 if no mask set)
+        old_mask = self.mask
+        old_values = (
+            old_mask.values.ravel().tolist()
+            if isinstance(old_mask, xr.DataArray)
+            else old_mask.ravel().tolist()
+        )
+
+        # Build and execute command
+        mask_edit_command = MaskEditCommand(
+            self,
+            all_indices,
+            new_values,
+            old_values=old_values,
+            message="Apply Land Fraction Mask",
+        )
+        self.tcm.execute(mask_edit_command, cmd_type=CommandType.COMMAND)
 
         # legacy code set the depth of land cells to depth_fillval, but now that is handled in the depth property.
 
@@ -1325,11 +1385,14 @@ class Topo:
             },
         )
 
-        # Write unmasked depth to file
-        ds["unmasked_depth"] = xr.DataArray(
-            self._unmasked_depth.data,
+        # Write raw depth to file
+        ds["depth_raw"] = xr.DataArray(
+            self._depth_raw.data,
             dims=["ny", "nx"],
-            attrs={"long_name": "t-grid cell depth", "units": "m"},
+            attrs={
+                "long_name": "t-grid cell depth (raw, before masking)",
+                "units": "m",
+            },
         )
 
         # Write masked depth (from property) to file

--- a/mom6_forge/topo_editor.py
+++ b/mom6_forge/topo_editor.py
@@ -1,3 +1,5 @@
+# All cell indices in this file are in (j, i) order to match (y, x) ordering
+
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib.patches as patches
@@ -6,6 +8,7 @@ import cartopy.crs as ccrs
 from matplotlib.ticker import MaxNLocator
 from mom6_forge.edit_command import *
 from mom6_forge.git_utils import *
+from matplotlib.widgets import RectangleSelector
 
 
 class TopoEditor(widgets.HBox):
@@ -19,15 +22,26 @@ class TopoEditor(widgets.HBox):
         self._selected_cell = None
         self._original_depth = np.array(self.topo.depth.data)
         self._original_min_depth = self.topo.min_depth
+        self._selected_cells = []
 
         # --- Build UI controls, plot, and observers ---
         self.construct_control_panel()
         self.construct_interactive_plot()
         self.construct_observances()
         self.update_undo_redo_buttons()
+        self.trigger_refresh()
 
         # --- Initialize the widget layout ---
         super().__init__([self._control_panel, self._interactive_plot])
+
+    @property
+    def active_cells(self):
+        if hasattr(self, "_selected_cells") and self._selected_cells:
+            return list(self._selected_cells)
+        elif self._selected_cell is not None:
+            i, j, *_ = self._selected_cell
+            return [(j, i)]
+        return []
 
     def apply_edit(self, cmd):
         """Apply an edit command, update the UI, and autosave the working state."""
@@ -121,6 +135,15 @@ class TopoEditor(widgets.HBox):
         self._interactive_plot = widgets.HBox(
             children=(self.fig.canvas,), layout={"border_left": "1px solid grey"}
         )
+        self._rect_selector = RectangleSelector(
+            self.ax,
+            self._on_rect_select,
+            useblit=True,
+            button=[1],
+            interactive=True,
+            props=dict(edgecolor="red", facecolor="red", alpha=0.2, fill=True),
+        )
+        self._rect_selector.set_active(False)  # off by default
 
     def construct_control_panel(self):
         """
@@ -154,6 +177,12 @@ class TopoEditor(widgets.HBox):
         self._selected_cell_label = widgets.Label(
             "Selected cell: None (double click to select a cell)."
         )
+        self._rect_select_button = widgets.ToggleButton(
+            value=False,
+            description="Rectangle Select",
+            button_style="info",
+            layout={"width": "80%"},
+        )
         self._depth_specifier = widgets.FloatText(
             value=None,
             step=10.0,
@@ -169,12 +198,15 @@ class TopoEditor(widgets.HBox):
             options=["Land", "Ocean"],
             description="Mask:",
             disabled=True,
+            layout={"width": "80%"},
             style={"description_width": "auto"},
         )
         self._clear_manual_mask_button = widgets.Button(
             description="Clear Manual Mask",
+            disabled=True,
             button_style="warning",
             layout={"width": "80%"},
+            style={"description_width": "auto"},
         )
 
         # --- Basin editing widgets ---
@@ -236,36 +268,36 @@ class TopoEditor(widgets.HBox):
             description="Checkout", layout={"width": "44%"}
         )
         # --- Group controls into logical sections ---
-        display_section = widgets.VBox(
+        self.display_section = widgets.VBox(
             [
                 widgets.HTML("<h3>Display</h3>"),
                 self._display_mode_toggle,
             ]
         )
-        global_settings_section = widgets.VBox(
+        self.global_settings_section = widgets.VBox(
             [
                 widgets.HTML("<h3>Global Settings</h3>"),
                 self._min_depth_specifier,
             ]
         )
-        cell_editing_section = widgets.VBox(
+        self.cell_editing_section = widgets.VBox(
             [
                 widgets.HTML("<h3>Cell Editing</h3>"),
+                self._rect_select_button,
                 self._selected_cell_label,
                 self._depth_specifier,
                 self._mask_specifier,
                 self._clear_manual_mask_button,
             ]
         )
-        basin_section = widgets.VBox(
+        self.basin_section = widgets.VBox(
             [
-                widgets.HTML("<h3>Basin Selector</h3>"),
                 self._basin_specifier,
                 self._basin_specifier_toggle,
                 self._basin_specifier_delete_selected,
             ]
         )
-        history_section = widgets.VBox(
+        self.history_section = widgets.VBox(
             [
                 widgets.HTML("<h3>Edit History</h3>"),
                 widgets.HBox(
@@ -273,7 +305,7 @@ class TopoEditor(widgets.HBox):
                 ),
             ]
         )
-        git_section = widgets.VBox(
+        self.git_section = widgets.VBox(
             [
                 # Domain controls
                 widgets.HTML("<hr>"),
@@ -290,25 +322,25 @@ class TopoEditor(widgets.HBox):
         )
 
         # --- Layout: always-visible controls and advanced accordions ---
-        main_controls = widgets.VBox(
+        self.main_controls = widgets.VBox(
             [
-                display_section,
-                global_settings_section,
-                cell_editing_section,
-                basin_section,
-                history_section,
+                self.display_section,
+                self.global_settings_section,
+                self.cell_editing_section,
+                self.basin_section,
+                self.history_section,
             ]
         )
-        git_accordion = widgets.Accordion(children=[git_section])
-        git_accordion.set_title(0, "Git Version Control")
-        git_accordion.selected_index = None  # collapsed by default
+        self.git_accordion = widgets.Accordion(children=[self.git_section])
+        self.git_accordion.set_title(0, "Git Version Control")
+        self.git_accordion.selected_index = None  # collapsed by default
 
         # --- Combine everything into the control panel ---
         self._control_panel = widgets.VBox(
             [
                 widgets.HTML("<h2>Topo Editor</h2>"),
-                main_controls,
-                git_accordion,
+                self.main_controls,
+                self.git_accordion,
             ],
             layout={"width": "30%", "height": "100%", "overflow_y": "auto"},
         )
@@ -321,6 +353,12 @@ class TopoEditor(widgets.HBox):
     def refresh_display_mode(self, change):
         """Refresh the display mode of the topography plot based on the selected mode."""
         mode = change["new"]
+        self._depth_specifier.layout.display = "flex" if mode == "depth" else "none"
+        self._mask_specifier.layout.display = "flex" if mode == "mask" else "none"
+        self._clear_manual_mask_button.layout.display = (
+            "flex" if mode == "mask" else "none"
+        )
+        self.basin_section.layout.display = "flex" if mode == "basinmask" else "none"
         if mode == "depth":
             self.im.set_clim(
                 vmin=self.topo.min_depth, vmax=float(np.nanmax(self.topo.depth.data))
@@ -400,7 +438,9 @@ class TopoEditor(widgets.HBox):
             self._depth_specifier.value = self.topo.depth.data[j, i]
         if hasattr(self, "_mask_specifier"):
             self._mask_specifier.disabled = False
-            self._mask_specifier.value = "Ocean" if self.topo.mask.data[j, i] == 1 else "Land"
+            self._mask_specifier.value = (
+                "Ocean" if self.topo.mask.data[j, i] == 1 else "Land"
+            )
         if hasattr(self, "_clear_manual_mask_button"):
             if self.topo._manual_mask is not None:
                 self._clear_manual_mask_button.disabled = False
@@ -428,6 +468,7 @@ class TopoEditor(widgets.HBox):
 
         # Double click event for cell selection on the plot
         self.fig.canvas.mpl_connect("button_press_event", self.on_double_click)
+        self._rect_select_button.observe(self._on_rect_select_toggle, names="value")
 
         # Min depth change observer
         self._min_depth_specifier.observe(
@@ -444,9 +485,7 @@ class TopoEditor(widgets.HBox):
         )
 
         # Mask change observer for selected cell
-        self._mask_specifier.observe(
-            self.on_mask_change, names="value", type="change"
-        )
+        self._mask_specifier.observe(self.on_mask_change, names="value", type="change")
         self._clear_manual_mask_button.on_click(self.clear_manual_mask)
 
         # Undo/Redo/Reset buttons
@@ -460,11 +499,56 @@ class TopoEditor(widgets.HBox):
         # Git/domain controls
         self._git_create_branch_button.on_click(self.on_git_create_branch)
         self._git_checkout_button.on_click(self.on_git_checkout)
-        self._display_mode_toggle.observe(
-            self.refresh_display_mode, names="value", type="change"
-        )
 
     # --- UI Callback Methods ---
+    def _on_rect_select_toggle(self, change):
+        if change["new"]:  # rectangle mode ON
+            # Clear the single-cell polygon patch if it exists
+            if self._selected_cell is not None and self._selected_cell[2] is not None:
+                try:
+                    self._selected_cell[2].remove()
+                except Exception:
+                    pass
+            self._rect_selector.set_active(True)
+            self._rect_select_button.button_style = "info"
+            self._rect_select_button.description = "Rectangle Select ✓"
+        else:  # rectangle mode OFF
+            self._rect_selector.set_active(False)
+            self._rect_selector.clear()  # removes the drawn box
+            self.fig.canvas.draw_idle()  # force redraw
+            self._rect_select_button.button_style = ""
+            self._rect_select_button.description = "Rectangle Select"
+            self._selected_cells = []
+            self._selected_cell_label.value = (
+                "Selected cell: None (double click to select a cell)."
+            )
+            self._depth_specifier.disabled = True
+            self._mask_specifier.disabled = True
+
+    def _on_rect_select(self, eclick, erelease):
+        lon_min, lon_max = sorted([eclick.xdata, erelease.xdata])
+        lat_min, lat_max = sorted([eclick.ydata, erelease.ydata])
+        lon_min = (lon_min + 360) % 360
+        lon_max = (lon_max + 360) % 360
+        tlon = self.topo._grid.tlon.data
+        tlat = self.topo._grid.tlat.data
+
+        mask = (
+            (tlon >= lon_min)
+            & (tlon <= lon_max)
+            & (tlat >= lat_min)
+            & (tlat <= lat_max)
+        )
+        self._selected_cells = list(zip(*np.where(mask)))
+
+        n = len(self._selected_cells)
+        self._selected_cell_label.value = (
+            f"Selected cells: n = {n}"
+            if n > 0
+            else f"Selected cell: None (draw box to select cells)."
+        )
+        self._depth_specifier.disabled = False
+        self._mask_specifier.disabled = False
 
     def on_tag(self, _btn=None):
         """Save the current state as a snapshot and commit it to the repository."""
@@ -479,6 +563,10 @@ class TopoEditor(widgets.HBox):
 
     def on_double_click(self, event):
         """Handle double-click events on the plot to select a cell."""
+        if (
+            self._rect_select_button.value
+        ):  # rectangle mode active, ignore double clicks
+            return
         if event.dblclick and event.xdata is not None and event.ydata is not None:
             # Convert lon/lat to grid indices
             j, i = self.topo._grid.get_indices(event.ydata, event.xdata)
@@ -509,6 +597,7 @@ class TopoEditor(widgets.HBox):
         if self.topo._manual_mask is not None:
             self.topo.clear_manual_mask()
             self.update_undo_redo_buttons()
+            self.trigger_refresh()
 
     def erase_selected_basin(self, b):
         """Erase the basin associated with the currently selected cell."""
@@ -520,28 +609,36 @@ class TopoEditor(widgets.HBox):
 
     def on_depth_change(self, change):
         """Handle changes to the depth specifier for the selected cell."""
-        if self._selected_cell is None:
+        if not self.active_cells:
             return
-        i, j, _ = self._selected_cell
-        old_val = self.topo.depth.data[j, i]
+        cells = self.active_cells
+        old_values = [self.topo.depth.data[j, i] for j, i in cells]
         new_val = change["new"]
-        if old_val == new_val:
+        if all(v == new_val for v in old_values):
             return
-        cmd = DepthEditCommand(self.topo, [(j, i)], [new_val], old_values=[old_val])
+        cmd = DepthEditCommand(
+            self.topo, cells, [new_val] * len(cells), old_values=old_values
+        )
         self.apply_edit(cmd)
         self.update_undo_redo_buttons()
 
     def on_mask_change(self, change):
-        """Handle changes to the mask specifier for the selected cell."""
-        if self._selected_cell is None:
+        if not self.active_cells:
             return
-        i, j, _ = self._selected_cell
-        old_val = self.topo.mask.data[j, i]
+        cells = self.active_cells
         mask_map = {"Land": 0, "Ocean": 1}
         new_val = mask_map[change["new"]]
-        if old_val == new_val:
+        old_values = [self.topo.mask.data[j, i] for j, i in cells]
+
+        if all(v == new_val for v in old_values):
             return
-        cmd = MaskEditCommand(self.topo, [(j, i)], [new_val], old_values=[old_val])
+
+        cmd = MaskEditCommand(
+            self.topo,
+            [(j, i) for j, i in cells],
+            [new_val] * len(cells),
+            old_values=old_values,
+        )
         self.apply_edit(cmd)
         self.update_undo_redo_buttons()
 

--- a/mom6_forge/topo_editor.py
+++ b/mom6_forge/topo_editor.py
@@ -9,6 +9,7 @@ from matplotlib.ticker import MaxNLocator
 from mom6_forge.edit_command import *
 from mom6_forge.git_utils import *
 from matplotlib.widgets import RectangleSelector
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 
 class TopoEditor(widgets.HBox):
@@ -39,7 +40,7 @@ class TopoEditor(widgets.HBox):
         if hasattr(self, "_selected_cells") and self._selected_cells:
             return list(self._selected_cells)
         elif self._selected_cell is not None:
-            i, j, *_ = self._selected_cell
+            j, i, *_ = self._selected_cell
             return [(j, i)]
         return []
 
@@ -132,9 +133,13 @@ class TopoEditor(widgets.HBox):
         plt.ion()  # Restore interactive mode
 
         # Wrap the figure in a widget for display
-        self._interactive_plot = widgets.HBox(
-            children=(self.fig.canvas,), layout={"border_left": "1px solid grey"}
-        )
+
+        if isinstance(self.fig.canvas, FigureCanvasAgg):  # For testing
+            self._interactive_plot = widgets.VBox([])  # empty placeholder
+        else:
+            self._interactive_plot = widgets.HBox(
+                children=(self.fig.canvas,), layout={"border_left": "1px solid grey"}
+            )
         self._rect_selector = RectangleSelector(
             self.ax,
             self._on_rect_select,
@@ -428,7 +433,7 @@ class TopoEditor(widgets.HBox):
             except Exception as e:
                 print(f"Failed to draw polygon patch: {e}")
 
-        self._selected_cell = (i, j, polygon)
+        self._selected_cell = (j, i, polygon)
 
         # UI updates
         if hasattr(self, "_selected_cell_label"):
@@ -588,7 +593,7 @@ class TopoEditor(widgets.HBox):
         """Erase all disconnected basins in the topography."""
         if self._selected_cell is None:
             return
-        i, j, _ = self._selected_cell
+        j, i, _ = self._selected_cell
         self.topo.erase_disconnected_basin(i, j)
         self.update_undo_redo_buttons()
 
@@ -603,7 +608,7 @@ class TopoEditor(widgets.HBox):
         """Erase the basin associated with the currently selected cell."""
         if self._selected_cell is None:
             return
-        i, j, _ = self._selected_cell
+        j, i, _ = self._selected_cell
         self.topo.erase_selected_basin(i, j)
         self.update_undo_redo_buttons()
 

--- a/mom6_forge/topo_editor.py
+++ b/mom6_forge/topo_editor.py
@@ -164,6 +164,19 @@ class TopoEditor(widgets.HBox):
             style={"description_width": "auto"},
         )
 
+        self._mask_specifier = widgets.ToggleButtons(
+            value=None,
+            options=["Land", "Ocean"],
+            description="Mask:",
+            disabled=True,
+            style={"description_width": "auto"},
+        )
+        self._clear_manual_mask_button = widgets.Button(
+            description="Clear Manual Mask",
+            button_style="warning",
+            layout={"width": "80%"},
+        )
+
         # --- Basin editing widgets ---
         self._basin_specifier_toggle = widgets.Button(
             description="Erase Disconnected Basins",
@@ -240,6 +253,8 @@ class TopoEditor(widgets.HBox):
                 widgets.HTML("<h3>Cell Editing</h3>"),
                 self._selected_cell_label,
                 self._depth_specifier,
+                self._mask_specifier,
+                self._clear_manual_mask_button,
             ]
         )
         basin_section = widgets.VBox(
@@ -316,7 +331,7 @@ class TopoEditor(widgets.HBox):
             )  # For some reason, this needs to be set twice to get the correct minimum bound
             self.cbar.set_label(f"Depth ({self.topo.depth.units})")
         elif mode == "mask":
-            self.im.set_array(self.topo.tmask.data)
+            self.im.set_array(self.topo.mask.data)
             self.im.set_clim((0, 1))
             self.cbar.set_label("Land Mask")
         elif mode == "basinmask":
@@ -383,6 +398,14 @@ class TopoEditor(widgets.HBox):
         if hasattr(self, "_depth_specifier"):
             self._depth_specifier.disabled = False
             self._depth_specifier.value = self.topo.depth.data[j, i]
+        if hasattr(self, "_mask_specifier"):
+            self._mask_specifier.disabled = False
+            self._mask_specifier.value = "Ocean" if self.topo.mask.data[j, i] == 1 else "Land"
+        if hasattr(self, "_clear_manual_mask_button"):
+            if self.topo._manual_mask is not None:
+                self._clear_manual_mask_button.disabled = False
+            else:
+                self._clear_manual_mask_button.disabled = True
         if hasattr(self, "_basin_specifier"):
             label = self.topo.basintmask.data[j, i]
             self._basin_specifier.value = f"Basin Label Number: {str(label)}"
@@ -419,6 +442,12 @@ class TopoEditor(widgets.HBox):
         self._depth_specifier.observe(
             self.on_depth_change, names="value", type="change"
         )
+
+        # Mask change observer for selected cell
+        self._mask_specifier.observe(
+            self.on_mask_change, names="value", type="change"
+        )
+        self._clear_manual_mask_button.on_click(self.clear_manual_mask)
 
         # Undo/Redo/Reset buttons
         self._undo_button.on_click(self.undo_last_edit)
@@ -475,6 +504,12 @@ class TopoEditor(widgets.HBox):
         self.topo.erase_disconnected_basin(i, j)
         self.update_undo_redo_buttons()
 
+    def clear_manual_mask(self, b):
+        """Clear the manual mask if it exists."""
+        if self.topo._manual_mask is not None:
+            self.topo.clear_manual_mask()
+            self.update_undo_redo_buttons()
+
     def erase_selected_basin(self, b):
         """Erase the basin associated with the currently selected cell."""
         if self._selected_cell is None:
@@ -493,6 +528,20 @@ class TopoEditor(widgets.HBox):
         if old_val == new_val:
             return
         cmd = DepthEditCommand(self.topo, [(j, i)], [new_val], old_values=[old_val])
+        self.apply_edit(cmd)
+        self.update_undo_redo_buttons()
+
+    def on_mask_change(self, change):
+        """Handle changes to the mask specifier for the selected cell."""
+        if self._selected_cell is None:
+            return
+        i, j, _ = self._selected_cell
+        old_val = self.topo.mask.data[j, i]
+        mask_map = {"Land": 0, "Ocean": 1}
+        new_val = mask_map[change["new"]]
+        if old_val == new_val:
+            return
+        cmd = MaskEditCommand(self.topo, [(j, i)], [new_val], old_values=[old_val])
         self.apply_edit(cmd)
         self.update_undo_redo_buttons()
 

--- a/notebooks/6_demo_editors.ipynb
+++ b/notebooks/6_demo_editors.ipynb
@@ -38,19 +38,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "c54b08a3-0c12-4f63-a686-f7ceba206fe9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -66,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "6f3d8331-1d17-4f6d-9145-3ebe1db8b0e3",
    "metadata": {},
    "outputs": [],
@@ -74,7 +65,7 @@
     "from mom6_forge.grid import Grid\n",
     "%matplotlib ipympl\n",
     "grid = Grid(\n",
-    "  resolution = 0.01,\n",
+    "  resolution = 0.1,\n",
     "  xstart = 281.0,\n",
     "  lenx = 5.0,\n",
     "  ystart = 35.0,\n",
@@ -103,22 +94,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "d96dc0fb-0138-4727-a2a6-cdae762a7376",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bd712d20c9e34606bc8355b8eb64f3bf",
+       "model_id": "48d13279e51c4a7283357cd79e5e4748",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "GridCreator(children=(VBox(children=(VBox(children=(HTML(value='<h3>Grid Creator</h3>'), FloatSlider(value=0.0…"
+       "GridCreator(children=(VBox(children=(VBox(children=(HTML(value='<h3>Grid Creator</h3>'), FloatSlider(value=0.1…"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "2e5e8392-38ff-47e9-bdef-d72ec4a82599",
    "metadata": {},
    "outputs": [],
@@ -225,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "892683a2-55e3-4752-9fba-980a15fda2dc",
    "metadata": {},
    "outputs": [],
@@ -261,14 +252,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "0bbe0329-b200-474c-98d4-dbfaaef5d3cf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ff31e4070e4400a86890a2b7f68ab55",
+       "model_id": "72c716a566be43839f5cbf52e6867225",
        "version_major": 2,
        "version_minor": 0
       },
@@ -276,9 +267,45 @@
        "TopoEditor(children=(VBox(children=(HTML(value='<h2>Topo Editor</h2>'), VBox(children=(VBox(children=(HTML(val…"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mAssertionError\u001b[39m                            Traceback (most recent call last)",
+      "\u001b[36mFile \u001b[39m\u001b[32m/glade/work/manishrv/conda-envs/mom6_forge/lib/python3.14/site-packages/ipywidgets/widgets/widget.py:191\u001b[39m, in \u001b[36mCallbackDispatcher.__call__\u001b[39m\u001b[34m(self, *args, **kwargs)\u001b[39m\n\u001b[32m    189\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m callback \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.callbacks:\n\u001b[32m    190\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m191\u001b[39m         local_value = \u001b[43mcallback\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    192\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    193\u001b[39m         ip = get_ipython()\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/documents/croc/regional_mom_workflows/mom6_forge/mom6_forge/topo_editor.py:50\u001b[39m, in \u001b[36mundo_last_edit\u001b[39m\u001b[34m(self, b)\u001b[39m\n\u001b[32m     47\u001b[39m     \u001b[38;5;28mself\u001b[39m.topo.tcm.execute(cmd)\n\u001b[32m     48\u001b[39m     \u001b[38;5;28mself\u001b[39m.trigger_refresh()\n\u001b[32m---> \u001b[39m\u001b[32m50\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mundo_last_edit\u001b[39m(\u001b[38;5;28mself\u001b[39m, b=\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[32m     51\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Undo the last edit command and update the UI.\"\"\"\u001b[39;00m\n\u001b[32m     52\u001b[39m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m.topo.tcm.undo()\n",
+      "\u001b[31mAssertionError\u001b[39m: "
+     ]
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mAssertionError\u001b[39m                            Traceback (most recent call last)",
+      "\u001b[36mFile \u001b[39m\u001b[32m/glade/work/manishrv/conda-envs/mom6_forge/lib/python3.14/site-packages/ipywidgets/widgets/widget.py:191\u001b[39m, in \u001b[36mCallbackDispatcher.__call__\u001b[39m\u001b[34m(self, *args, **kwargs)\u001b[39m\n\u001b[32m    189\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m callback \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.callbacks:\n\u001b[32m    190\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m191\u001b[39m         local_value = \u001b[43mcallback\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    192\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    193\u001b[39m         ip = get_ipython()\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/documents/croc/regional_mom_workflows/mom6_forge/mom6_forge/topo_editor.py:50\u001b[39m, in \u001b[36mundo_last_edit\u001b[39m\u001b[34m(self, b)\u001b[39m\n\u001b[32m     47\u001b[39m     \u001b[38;5;28mself\u001b[39m.topo.tcm.execute(cmd)\n\u001b[32m     48\u001b[39m     \u001b[38;5;28mself\u001b[39m.trigger_refresh()\n\u001b[32m---> \u001b[39m\u001b[32m50\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mundo_last_edit\u001b[39m(\u001b[38;5;28mself\u001b[39m, b=\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[32m     51\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Undo the last edit command and update the UI.\"\"\"\u001b[39;00m\n\u001b[32m     52\u001b[39m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m.topo.tcm.undo()\n",
+      "\u001b[31mAssertionError\u001b[39m: "
+     ]
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mAssertionError\u001b[39m                            Traceback (most recent call last)",
+      "\u001b[36mFile \u001b[39m\u001b[32m/glade/work/manishrv/conda-envs/mom6_forge/lib/python3.14/site-packages/ipywidgets/widgets/widget.py:191\u001b[39m, in \u001b[36mCallbackDispatcher.__call__\u001b[39m\u001b[34m(self, *args, **kwargs)\u001b[39m\n\u001b[32m    189\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m callback \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.callbacks:\n\u001b[32m    190\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m191\u001b[39m         local_value = \u001b[43mcallback\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    192\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    193\u001b[39m         ip = get_ipython()\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/documents/croc/regional_mom_workflows/mom6_forge/mom6_forge/topo_editor.py:50\u001b[39m, in \u001b[36mundo_last_edit\u001b[39m\u001b[34m(self, b)\u001b[39m\n\u001b[32m     47\u001b[39m     \u001b[38;5;28mself\u001b[39m.topo.tcm.execute(cmd)\n\u001b[32m     48\u001b[39m     \u001b[38;5;28mself\u001b[39m.trigger_refresh()\n\u001b[32m---> \u001b[39m\u001b[32m50\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mundo_last_edit\u001b[39m(\u001b[38;5;28mself\u001b[39m, b=\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[32m     51\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Undo the last edit command and update the UI.\"\"\"\u001b[39;00m\n\u001b[32m     52\u001b[39m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m.topo.tcm.undo()\n",
+      "\u001b[31mAssertionError\u001b[39m: "
+     ]
     }
    ],
    "source": [
@@ -572,9 +599,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:mom6_forge]",
+   "display_name": "mom6_forge",
    "language": "python",
-   "name": "conda-env-mom6_forge-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -586,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.15"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,10 @@ import numpy as np
 import pytest
 from mom6_forge.grid import Grid
 from mom6_forge.topo import Topo
+import matplotlib
+from mom6_forge.topo_editor import TopoEditor
+
+matplotlib.use("Agg")  # must be before any other matplotlib import
 
 
 @pytest.fixture
@@ -252,3 +256,8 @@ def get_rect_topo(get_rect_grid, tmp_path):
     topo = Topo(get_rect_grid, min_depth=0, version_control_dir=tmp_path)
     topo.set_flat(1000)
     return topo
+
+
+@pytest.fixture
+def get_editor(get_rect_topo):
+    return TopoEditor(get_rect_topo)

--- a/tests/test_edit_commands.py
+++ b/tests/test_edit_commands.py
@@ -56,3 +56,53 @@ def test_serialize_deserialize_DepthEditCommand(gen_DepthEditCommand):
     assert rdc.affected_indices == command.affected_indices
     assert rdc.new_values == command.old_values
     assert rdc.old_values == command.new_values
+
+
+@pytest.fixture
+def gen_MaskEditCommand(get_rect_topo):
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+    indices = [(0, 0), (0, 1), (1, 0)]
+    new_values = [1, 1, 0]
+    command = MaskEditCommand(topo, indices, new_values)
+    return command
+
+
+def test_MaskEditCommand_init_and_execute(gen_MaskEditCommand):
+    command = gen_MaskEditCommand
+    command()
+    # Verify manual mask was initialized
+    assert command._topo._manual_mask is not None
+    # Verify values were set
+    assert command._topo.mask[0, 0] == 1
+    assert command._topo.mask[0, 1] == 1
+    assert command._topo.mask[1, 0] == 0
+
+
+def test_serialize_deserialize_MaskEditCommand(gen_MaskEditCommand):
+    command = gen_MaskEditCommand
+    command()  # Execute to set mask
+    serialized = command.serialize()
+    deserialized_command = MaskEditCommand.deserialize(serialized)(command._topo)
+    rdc = MaskEditCommand.reverse_deserialize(serialized)(command._topo)
+    assert deserialized_command.affected_indices == command.affected_indices
+    assert deserialized_command.new_values == command.new_values
+    assert rdc.affected_indices == command.affected_indices
+    assert rdc.new_values == command.old_values
+
+
+def test_ClearMaskCommand_init_and_execute(get_rect_topo):
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Set a mask first
+    import numpy as np
+
+    mask = np.ones((ny, nx), dtype=int)
+    topo.mask = mask
+    assert topo._manual_mask is not None
+
+    # Clear it
+    command = ClearMaskCommand(topo)
+    command()
+    assert topo._manual_mask is None

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -1,0 +1,165 @@
+"""Test mask functionality: setting, applying, and depth masking behavior."""
+
+import numpy as np
+import pytest
+import xarray as xr
+from mom6_forge.edit_command import MaskEditCommand, ClearMaskCommand
+
+
+def test_mask_setter_and_getter(get_rect_topo):
+    """Test setting and getting mask property."""
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Create a simple binary mask (half ocean, half land)
+    mask = np.ones((ny, nx), dtype=int)
+    mask[:, : nx // 2] = 0  # Western half is land
+
+    # Set mask
+    topo.mask = mask
+
+    # Get mask and verify
+    retrieved_mask = topo.mask
+    assert (retrieved_mask == mask).all()
+
+
+def test_mask_applies_to_depth(get_rect_topo):
+    """Test that mask modifies depth property correctly."""
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Store raw depth before masking
+    raw_depth = topo.depth.copy()
+
+    # Create binary mask: eastern half ocean (1), western half land (0)
+    mask = np.zeros((ny, nx), dtype=int)
+    mask[:, nx // 2 :] = 1
+
+    # Set land fill value
+    topo.land_fillval = 0.0
+    topo.mask = mask
+
+    # Get masked depth
+    masked_depth = topo.depth
+
+    # Verify ocean cells (mask=1) keep original depth
+    assert (masked_depth[:, nx // 2 :] > topo.min_depth).all()
+
+    # Verify land cells (mask=0) are set to land_fillval
+    assert (masked_depth[:, : nx // 2] == 0.0).all()
+
+
+def test_mask_none_disables_masking(get_rect_topo):
+    """Test that setting mask=None disables masking."""
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Apply a mask
+    mask = np.ones((ny, nx), dtype=int)
+    mask[:, : nx // 2] = 0
+    topo.mask = mask
+
+    # Verify mask is applied
+    assert not (topo.depth == topo.depth_raw).all()
+
+    # Clear mask
+    topo.mask = None
+
+    # Verify depth returns to raw
+    assert (topo.depth == topo.depth_raw).all()
+
+
+def test_land_fillval_property(get_rect_topo):
+    """Test setting and validating land_fillval."""
+    topo = get_rect_topo
+
+    # Test setting land_fillval
+    topo.land_fillval = 0.0
+    assert topo.land_fillval == 0.0
+
+    # Test validation: land_fillval must be <= min_depth
+    with pytest.raises(AssertionError):
+        topo.land_fillval = topo.min_depth + 1.0
+
+
+def test_land_fillval_affects_masked_depth(get_rect_topo):
+    """Test that land_fillval is used in masked depth."""
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Create all-land mask
+    mask = np.zeros((ny, nx), dtype=int)
+
+    # Set custom land fill value
+    custom_fill = -100.0
+    topo.land_fillval = custom_fill
+    topo.mask = mask
+
+    # Verify all depth values are land_fillval
+    assert (topo.depth == custom_fill).all()
+
+
+def test_depth_raw_property(get_rect_topo):
+    """Test depth_raw property reads and writes correctly."""
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Get raw depth
+    raw = topo.depth_raw
+    assert raw.shape == (ny, nx)
+
+    # Modify raw depth
+    new_depth = np.full((ny, nx), 2000.0)
+    topo.depth_raw = new_depth
+
+    # Verify it was updated
+    assert (topo.depth_raw == 2000.0).all()
+
+
+def test_depth_raw_preserves_mask(get_rect_topo):
+    """Test that setting depth_raw preserves existing mask."""
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Apply a mask
+    mask = np.ones((ny, nx), dtype=int)
+    mask[:, : nx // 2] = 0
+    topo.mask = mask
+
+    # Modify raw depth
+    new_depth = np.full((ny, nx), 3000.0)
+    topo.depth_raw = new_depth
+
+    # Verify mask is still applied
+    masked_depth = topo.depth
+    assert (masked_depth[:, : nx // 2] == topo.land_fillval).all()
+    assert (masked_depth[:, nx // 2 :] > topo.min_depth).all()
+
+
+def test_mask_shape_validation(get_rect_topo):
+    """Test that mask shape must match grid."""
+    topo = get_rect_topo
+
+    # Try to set mask with wrong shape
+    bad_mask = np.ones((10, 10), dtype=int)
+
+    with pytest.raises(AssertionError):
+        topo.mask = bad_mask
+
+
+def test_mask_initialization_from_depth_raw_mask(get_rect_topo):
+    """Test that LandEditCommand initializes mask from depth_raw_mask."""
+    topo = get_rect_topo
+    ny, nx = topo._grid.ny, topo._grid.nx
+
+    # Initially no manual mask
+    assert topo._manual_mask is None
+
+    # Create a simple edit command (which should auto-init mask)
+    indices = [(0, 0), (0, 1)]
+    values = [1, 1]
+    cmd = MaskEditCommand(topo, indices, values)
+    cmd()
+
+    # Verify mask was initialized
+    assert topo._manual_mask is not None

--- a/tests/test_topo_command_manager.py
+++ b/tests/test_topo_command_manager.py
@@ -101,9 +101,9 @@ def test_TopoCommandManager_reapply_changes(get_rect_topo, gen_MinDepthCommand):
     topo.tcm.execute(gen_MinDepthCommand)
     assert topo.min_depth == 10.0  # Assert Action taken
     prev_hist = sum(1 for _ in topo.tcm.repo.iter_commits())
-    store_depth = topo._depth.copy()
-    topo._depth = xr.zeros_like(
-        topo._depth
+    store_depth = topo._unmasked_depth.copy()
+    topo._unmasked_depth = xr.zeros_like(
+        topo._unmasked_depth
     )  # Corrupt the depth to ensure reapply_changes works
     topo.tcm.reapply_changes()
     assert (topo.depth == store_depth).all()  # Assert reapply worked

--- a/tests/test_topo_command_manager.py
+++ b/tests/test_topo_command_manager.py
@@ -101,9 +101,9 @@ def test_TopoCommandManager_reapply_changes(get_rect_topo, gen_MinDepthCommand):
     topo.tcm.execute(gen_MinDepthCommand)
     assert topo.min_depth == 10.0  # Assert Action taken
     prev_hist = sum(1 for _ in topo.tcm.repo.iter_commits())
-    store_depth = topo._unmasked_depth.copy()
-    topo._unmasked_depth = xr.zeros_like(
-        topo._unmasked_depth
+    store_depth = topo._depth_raw.copy()
+    topo._depth_raw = xr.zeros_like(
+        topo._depth_raw
     )  # Corrupt the depth to ensure reapply_changes works
     topo.tcm.reapply_changes()
     assert (topo.depth == store_depth).all()  # Assert reapply worked

--- a/tests/test_topo_editor.py
+++ b/tests/test_topo_editor.py
@@ -1,28 +1,164 @@
-import os
-import numpy as np
-import pytest
-import git
-import json
+import matplotlib
 
-from mom6_forge.grid import Grid
-from mom6_forge.topo import Topo
-from mom6_forge.edit_command import DepthEditCommand
-from mom6_forge.topo_editor import TopoEditor
+matplotlib.use("Agg")
+from unittest.mock import MagicMock
+
+# --- active_cells ---
 
 
-@pytest.fixture
-def minimal_grid_and_topo():
-    """Test that a minimal 5x5 grid can be set up for the Panama region"""
-    grid = Grid(
-        resolution=0.1, xstart=278.0, lenx=0.5, ystart=7.0, leny=0.5, name="testpanama"
-    )
-    topo = Topo(grid=grid, min_depth=10.0)
-    topo.set_spoon(2000.0, 200)
-    return topo
+def test_active_cells_empty(get_editor):
+    """No selection returns empty list."""
+    assert get_editor.active_cells == []
 
 
-def test_grid_topo(minimal_grid_and_topo):
-    topo = minimal_grid_and_topo
-    assert topo._grid.nx == 5
-    assert topo._grid.ny == 5
-    assert topo.depth.shape == (5, 5)
+def test_active_cells_single_cell(get_editor):
+    """Single cell selection returns correct (j, i) tuple."""
+    get_editor._select_cell(3, 2)  # note (i, j) order
+    assert get_editor.active_cells == [(2, 3)]
+
+
+def test_active_cells_rect(get_editor):
+    """Rectangle selection returns all selected (j, i) tuples."""
+    get_editor._selected_cells = [(0, 0), (0, 1), (1, 0)]
+    assert get_editor.active_cells == [(0, 0), (0, 1), (1, 0)]
+
+
+def test_active_cells_rect_takes_priority(get_editor):
+    """Rectangle selection takes priority over single cell."""
+    get_editor._select_cell(0, 0)
+    get_editor._selected_cells = [(1, 1), (2, 2)]
+    assert get_editor.active_cells == [(1, 1), (2, 2)]
+
+
+# --- mask ---
+
+
+def test_mask_single_cell(get_editor):
+    get_editor._select_cell(0, 0)
+    get_editor.on_mask_change({"new": "Land"})
+    assert get_editor.topo.mask.data[0, 0] == 0
+
+
+def test_mask_no_op_if_same_value(get_editor):
+    """Should not apply edit if mask value unchanged."""
+    get_editor._select_cell(0, 0)
+    get_editor.on_mask_change({"new": "Ocean"})
+    history_len = len(get_editor.topo.tcm.history_dict)
+    get_editor.on_mask_change({"new": "Ocean"})
+    assert len(get_editor.topo.tcm.history_dict) == history_len  # no new command
+
+
+def test_mask_multi_cell_rect(get_editor):
+    """Rectangle selection applies mask to all selected cells."""
+    get_editor._selected_cells = [(0, 0), (0, 1), (1, 0)]
+    get_editor.on_mask_change({"new": "Land"})
+    assert get_editor.topo.mask.data[0, 0] == 0
+    assert get_editor.topo.mask.data[0, 1] == 0
+    assert get_editor.topo.mask.data[1, 0] == 0
+
+
+def test_mask_no_selection(get_editor):
+    """No selection should not raise or apply any edit."""
+    get_editor.on_mask_change({"new": "Land"})  # should just return
+
+
+# --- depth ---
+
+
+def test_depth_single_cell(get_editor):
+    get_editor._select_cell(0, 0)
+    get_editor.on_depth_change({"new": 500.0})
+    assert get_editor.topo.depth.data[0, 0] == 500.0
+
+
+def test_depth_no_op_if_same_value(get_editor):
+    get_editor._select_cell(0, 0)
+    get_editor.on_depth_change({"new": 1000.0})  # already flat 1000
+    history_len = len(get_editor.topo.tcm.history_dict)
+    get_editor.on_depth_change({"new": 1000.0})
+    assert len(get_editor.topo.tcm.history_dict) == history_len
+
+
+def test_depth_multi_cell_rect(get_editor):
+    """Rectangle selection applies depth to all selected cells."""
+    get_editor._selected_cells = [(0, 0), (0, 1), (1, 0)]
+    get_editor.on_depth_change({"new": 200.0})
+    assert get_editor.topo.depth.data[0, 0] == 200.0
+    assert get_editor.topo.depth.data[0, 1] == 200.0
+    assert get_editor.topo.depth.data[1, 0] == 200.0
+
+
+# --- undo/redo ---
+
+
+def test_undo_depth_change(get_editor):
+    get_editor._select_cell(0, 0)
+    get_editor.on_depth_change({"new": 500.0})
+    assert get_editor.topo.depth.data[0, 0] == 500.0
+    get_editor.undo_last_edit()
+    assert get_editor.topo.depth.data[0, 0] == 1000.0
+
+
+def test_redo_depth_change(get_editor):
+    get_editor._select_cell(0, 0)
+    get_editor.on_depth_change({"new": 500.0})
+    get_editor.undo_last_edit()
+    get_editor.redo_last_edit()
+    assert get_editor.topo.depth.data[0, 0] == 500.0
+
+
+def test_undo_mask_change(get_editor):
+    get_editor._select_cell(0, 0)
+    original = get_editor.topo.mask.data[0, 0]
+    get_editor.on_mask_change({"new": "Land"})
+    get_editor.undo_last_edit()
+    assert get_editor.topo.mask.data[0, 0] == original
+
+
+# --- rect select toggle ---
+
+
+def test_rect_toggle_gates_double_click(get_editor):
+    """Double click should be ignored when rect mode is active."""
+    get_editor._rect_select_button.value = True
+    mock_event = MagicMock()
+    mock_event.dblclick = True
+    mock_event.xdata = 279.0
+    mock_event.ydata = 8.0
+    get_editor.on_double_click(mock_event)
+    assert get_editor._selected_cell is None
+
+
+def test_rect_toggle_off_clears_selection(get_editor):
+    """Turning off rect mode clears selected cells."""
+    get_editor._selected_cells = [(0, 0), (1, 1)]
+    get_editor._rect_select_button.value = True
+    get_editor._rect_select_button.value = False
+    assert get_editor._selected_cells == []
+
+
+# --- rect select logic ---
+
+
+def test_rect_select_finds_cells_in_bounds(get_editor):
+    """Cells within the rectangle bounds are selected."""
+    mock_eclick = MagicMock()
+    mock_erelease = MagicMock()
+    mock_eclick.xdata = 278.0
+    mock_eclick.ydata = 7.0
+    mock_erelease.xdata = 279.0
+    mock_erelease.ydata = 8.0
+    get_editor._on_rect_select(mock_eclick, mock_erelease)
+    assert len(get_editor._selected_cells) > 0
+
+
+def test_rect_select_empty_outside_bounds(get_editor):
+    """No cells selected when rectangle is outside the grid."""
+    mock_eclick = MagicMock()
+    mock_erelease = MagicMock()
+    mock_eclick.xdata = 0.0
+    mock_eclick.ydata = 0.0
+    mock_erelease.xdata = 1.0
+    mock_erelease.ydata = 1.0
+    get_editor._on_rect_select(mock_eclick, mock_erelease)
+    assert len(get_editor._selected_cells) == 0


### PR DESCRIPTION
Changes:

1. Add the mask variable to the topo editor in the form of using the topo mask property and adding a mask edit field that can be switched from land to ocean
2. Add a toggle to do rectangle select, to set large chunks of bathymetry to a specific value
3. Minor cleaning