### PR TITLE
Make radius optional in SupergridBase.__init__ with a warning

### DIFF
--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -40,7 +40,9 @@ class SupergridBase:
     def leny(self):
         return self.y.max() - self.y.min()
 
-    def __init__(self, x, y, dx, dy, area, angle_dx, axis_units, grid_type, radius=None):
+    def __init__(
+        self, x, y, dx, dy, area, angle_dx, axis_units, grid_type, radius=None
+    ):
         """
         Initialize a generic supergrid.
 

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -40,9 +40,7 @@ class SupergridBase:
     def leny(self):
         return self.y.max() - self.y.min()
 
-    def __init__(
-        self, x, y, dx, dy, area, angle_dx, axis_units, grid_type, radius=None
-    ):
+    def __init__(self, x, y, dx, dy, area, angle_dx, axis_units, grid_type):
         """
         Initialize a generic supergrid.
 
@@ -60,15 +58,7 @@ class SupergridBase:
             Units of x and y (e.g. "degrees" or "meters").
         grid_type : str
             the type of grid being created
-        radius : float, optional
-            Sphere radius in metres. If not provided, dx/dy/area cannot be
-            exactly retraced from the stored supergrid coordinates.
         """
-        if radius is None:
-            print(
-                "No radius provided: without a stored radius, dx, dy, and area "
-                "calculations cannot be exactly retraced from the supergrid coordinates.",
-            )
         self.x = x
         self.y = y
         self.dx = dx
@@ -77,7 +67,6 @@ class SupergridBase:
         self.angle_dx = angle_dx
         self.axis_units = axis_units
         self.grid_type = grid_type
-        self.radius = radius
 
     def __eq__(self, other):
         if not isinstance(other, SupergridBase):
@@ -174,9 +163,7 @@ class SupergridBase:
             angle_dx = SupergridBase.calc_supergrid_rotation_angles_using_expanded_supergrid_method(
                 x, y
             )
-        return cls(
-            x, y, dx, dy, area, angle_dx, "degrees", grid_type=grid_type, radius=R
-        )
+        return cls(x, y, dx, dy, area, angle_dx, "degrees", grid_type=grid_type)
 
     def summary(self):
         """Print a short summary of the grid geometry (shape and dx/dy ranges)."""
@@ -201,8 +188,6 @@ class SupergridBase:
         ds.attrs["type"] = "MOM6 supergrid"
         if self.grid_type is not None:
             ds.attrs["grid_type"] = self.grid_type
-        if self.radius is not None:
-            ds.attrs["radius"] = self.radius
         if name is not None:
             ds.attrs["name"] = name
         ds.attrs["Created"] = datetime.now().isoformat()
@@ -240,7 +225,6 @@ class SupergridBase:
             ds.angle_dx.data,
             ds.x.attrs.get("units", "degrees"),
             grid_type=ds.attrs.get("grid_type"),
-            radius=ds.attrs.get("radius"),
         )
 
     @staticmethod

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -40,7 +40,7 @@ class SupergridBase:
     def leny(self):
         return self.y.max() - self.y.min()
 
-    def __init__(self, x, y, dx, dy, area, angle_dx, axis_units, grid_type, radius):
+    def __init__(self, x, y, dx, dy, area, angle_dx, axis_units, grid_type, radius=None):
         """
         Initialize a generic supergrid.
 
@@ -58,7 +58,19 @@ class SupergridBase:
             Units of x and y (e.g. "degrees" or "meters").
         grid_type : str
             the type of grid being created
+        radius : float, optional
+            Sphere radius in metres. If not provided, dx/dy/area cannot be
+            exactly retraced from the stored supergrid coordinates.
         """
+        if radius is None:
+            import warnings
+
+            warnings.warn(
+                "No radius provided: without a stored radius, dx, dy, and area "
+                "calculations cannot be exactly retraced from the supergrid coordinates.",
+                UserWarning,
+                stacklevel=2,
+            )
         self.x = x
         self.y = y
         self.dx = dx
@@ -191,7 +203,8 @@ class SupergridBase:
         ds.attrs["type"] = "MOM6 supergrid"
         if self.grid_type is not None:
             ds.attrs["grid_type"] = self.grid_type
-        ds.attrs["radius"] = self.radius
+        if self.radius is not None:
+            ds.attrs["radius"] = self.radius
         if name is not None:
             ds.attrs["name"] = name
         ds.attrs["Created"] = datetime.now().isoformat()
@@ -229,7 +242,7 @@ class SupergridBase:
             ds.angle_dx.data,
             ds.x.attrs.get("units", "degrees"),
             grid_type=ds.attrs.get("grid_type"),
-            radius=ds.attrs["radius"],
+            radius=ds.attrs.get("radius"),
         )
 
     @staticmethod

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -65,13 +65,9 @@ class SupergridBase:
             exactly retraced from the stored supergrid coordinates.
         """
         if radius is None:
-            import warnings
-
-            warnings.warn(
+            print(
                 "No radius provided: without a stored radius, dx, dy, and area "
                 "calculations cannot be exactly retraced from the supergrid coordinates.",
-                UserWarning,
-                stacklevel=2,
             )
         self.x = x
         self.y = y


### PR DESCRIPTION
Warn when radius is None that dx/dy/area cannot be exactly retraced. Skip writing radius to netCDF attrs if absent; load it with .get() in from_ds.