### PR TITLE
Generalize get_bounding_boxes to non-rectangular regional grids

### DIFF
--- a/mom6_forge/grid.py
+++ b/mom6_forge/grid.py
@@ -426,7 +426,9 @@ class Grid:
         """
         if type(hgrid) == Grid:
             hgrid = hgrid._supergrid.to_ds()
-        assert not Grid.is_cyclic_x(hgrid), "Cannot compute bounding boxes for cyclic grids"
+        assert not Grid.is_cyclic_x(
+            hgrid
+        ), "Cannot compute bounding boxes for cyclic grids"
 
         init_result = {
             "lon_min": float(hgrid.x.min()),

--- a/mom6_forge/grid.py
+++ b/mom6_forge/grid.py
@@ -403,9 +403,9 @@ class Grid:
         )
 
     @classmethod
-    def get_bounding_boxes_of_rectangular_grid(cls, hgrid):
+    def get_bounding_boxes(cls, hgrid):
         """
-        Extract lat/lon bounding boxes for each edge of a rectangular regional MOM6 grid.
+        Extract lat/lon bounding boxes for each edge of a regional MOM6 grid.
         This function is used when subsetting global datasets (e.g. GLORYS)
         down to the lat/lon ranges required for efficient regridding:
             • north, south, east, west boundaries
@@ -425,13 +425,8 @@ class Grid:
                 • "ic" (full domain for initial conditions)
         """
         if type(hgrid) == Grid:
-            assert hgrid.is_rectangular()
             hgrid = hgrid._supergrid.to_ds()
-            assert not Grid.is_cyclic_x(hgrid)
-        else:
-            grid_check = Grid.from_supergrid_ds(hgrid)
-            assert grid_check.is_rectangular()
-            assert not Grid.is_cyclic_x(hgrid)
+        assert not Grid.is_cyclic_x(hgrid), "Cannot compute bounding boxes for cyclic grids"
 
         init_result = {
             "lon_min": float(hgrid.x.min()),

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -240,7 +240,7 @@ if __name__ == "__main__":
 
 def test_get_rectangular_segment_info(get_rect_grid):
     grid = get_rect_grid
-    res = Grid.get_bounding_boxes_of_rectangular_grid(grid)
+    res = Grid.get_bounding_boxes(grid)
     assert "east" in res.keys()
     assert "west" in res.keys()
     assert "north" in res.keys()

--- a/tests/test_ww3_input.py
+++ b/tests/test_ww3_input.py
@@ -84,3 +84,44 @@ def test_write_ww3_input_masked_cells_are_land(get_rect_topo, tmp_path):
     # mapsta is exactly the land/sea mask, and depth is zero wherever land.
     assert np.array_equal(mapsta, topo.tmask.data)
     assert (bottom[mapsta == 0] == 0.0).all()
+
+
+def test_write_ww3_input_after_reconstruction_from_files(get_rect_topo, tmp_path):
+    """visualCaseGen's WW3 input generator reconstructs the Grid/Topo from the saved ocean grid
+    files (ocean_hgrid + ocean_topog) before writing the *.inp files. Exercise that exact
+    sequence: save the grid/topo, reload via Grid.from_supergrid + Topo.from_topo_file, then
+    write the WW3 inputs and confirm they are produced and consistent with the grid."""
+    import xarray as xr
+    from mom6_forge.grid import Grid
+    from mom6_forge.topo import Topo
+
+    topo = get_rect_topo  # flat 1000 m depth, all ocean
+    alias = topo._grid.name
+
+    # Save the ocean grid files, as the mom6_forge notebook would.
+    supergrid_file = tmp_path / "ocean_hgrid.nc"
+    topo_file = tmp_path / "ocean_topog.nc"
+    topo._grid.write_supergrid(supergrid_file.as_posix())
+    topo.write_topo(topo_file.as_posix())
+
+    # Reconstruct from the saved files (mirrors WW3InputGenerator): read min_depth from the
+    # topog attribute so the WW3 land/sea mask matches the ocean mask. This also confirms
+    # write_topo persists the min_depth attribute.
+    with xr.open_dataset(topo_file) as ds_topo:
+        min_depth = float(ds_topo.attrs["min_depth"])
+    grid = Grid.from_supergrid(supergrid_file.as_posix())
+    reloaded = Topo.from_topo_file(grid, topo_file.as_posix(), min_depth=min_depth)
+
+    out_dir = tmp_path / "ocnice"
+    out_dir.mkdir()
+    reloaded.write_ww3_input(out_dir.as_posix(), grid_alias=alias)
+
+    for suffix in WW3_FILE_SUFFIXES:
+        assert (out_dir / f"{alias}{suffix}").exists()
+    assert (out_dir / "ww3_grid.inp").exists()
+
+    # Coordinates from the reconstructed grid still match the original t-points.
+    xcoord = np.loadtxt(out_dir / f"{alias}_x.inp")
+    ycoord = np.loadtxt(out_dir / f"{alias}_y.inp")
+    assert np.allclose(xcoord, topo._grid.tlon.data)
+    assert np.allclose(ycoord, topo._grid.tlat.data)


### PR DESCRIPTION
- Generalize get_bounding_boxes to non-rectangular regional grids. This was necessary to be able to carve out regional domains from curvilinear grids like tx2_3v2.
- Also add ww3 input write test.
