### PR TITLE
Collapse coincident pole node rows in write_esmf_mesh

### DIFF
--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -34,18 +34,23 @@ class SupergridBase:
 
     @property
     def is_tripolar(self):
-        nlines = 0
-        _, nx = self.x.shape
-        within_line = False
-        for i in range(0, nx - 1):
-            if not within_line:
-                if self.x[-1, i] == self.x[-1, i + 1]:
-                    within_line = True
-                    nlines += 1
-            else:
-                if self.x[-1, i] != self.x[-1, i + 1]:
-                    within_line = False
-        return nlines == 3
+        return SupergridBase.x_is_tripolar(self.x)
+
+    @staticmethod
+    def x_is_tripolar(x) -> bool:
+        """Return whether an ``x`` coordinate array is that of a tripolar grid.
+
+        A tripolar grid's top row runs along the seam joining its two poles, so
+        the longitude there holds steady over three stretches of the row. ``x``
+        can come from a supergrid or straight from an hgrid dataset.
+        """
+
+        x = np.asarray(x)
+        same_as_next = x[-1, :-1] == x[-1, 1:]
+        # count the stretches, i.e. the places where one starts
+        starts = same_as_next.copy()
+        starts[1:] &= ~same_as_next[:-1]
+        return int(np.count_nonzero(starts)) == 3
 
     @property
     def lenx(self):

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -277,7 +277,9 @@ class SupergridBase:
             (north_row, 90.0, "north"),
         ):
             # Only collapse when the *whole* edge row sits on the pole.
-            if row.size > 1 and np.all(np.isclose(lat[row], pole_val, atol=tol)):
+            if row.size > 1 and np.all(
+                np.isclose(lat[row], pole_val, rtol=0, atol=tol)
+            ):
                 rep = row[0]  # keep the first node of the fan
                 remap[row] = rep
                 keep[row[1:]] = False
@@ -299,12 +301,14 @@ class SupergridBase:
         return new_node_coords, new_element_conn, collapsed
 
     @staticmethod
-    def _expand_pole_node_rows(node_lon, node_lat, node_row_width, tol=1e-10):
+    def _expand_pole_node_rows(
+        node_lon, node_lat, node_row_width, n_node_rows, tol=1e-10
+    ):
         """Re-expand a collapsed pole node into a full row of nodes.
 
         Partial inverse of :meth:`_collapse_pole_node_rows` for the node table,
         used when reading a mesh back: it restores the rectangular
-        ``(ny+1, node_row_width)`` node layout that the reshape logic in
+        ``(n_node_rows, node_row_width)`` node layout that the reshape logic in
         :meth:`reconstruct_from_esmf_mesh` requires. Longitudes for the restored
         row are taken from the adjacent interior node row -- each column of a
         logically-rectangular lat-lon grid shares one longitude, so this recovers
@@ -316,6 +320,8 @@ class SupergridBase:
             Flattened node longitudes and latitudes, row-major (south row first).
         node_row_width : int
             Number of nodes per logical row (``nx`` for cyclic, ``nx+1`` otherwise).
+        n_node_rows : int
+            Number of logical node rows in the uncollapsed table (``ny+1``).
         tol : float, optional
             Absolute tolerance (degrees) for detecting nodes at a pole. Default 1e-10.
 
@@ -332,24 +338,36 @@ class SupergridBase:
         if w <= 1:
             return node_lon, node_lat, expanded
 
+        # Number of collapsed pole rows, from the node count alone.
+        missing = w * n_node_rows - node_lat.size
+        if missing <= 0 or missing % (w - 1) != 0:
+            return node_lon, node_lat, expanded
+        n_collapsed = missing // (w - 1)
+        if n_collapsed > 2:
+            return node_lon, node_lat, expanded
+
+        def _is_apex(i, j):
+            # Node i sits on a pole and its neighbour j in the adjacent row does
+            # not share its latitude, i.e. node i is a collapsed fan's apex.
+            return np.isclose(
+                abs(node_lat[i]), 90.0, rtol=0, atol=tol
+            ) and not np.isclose(node_lat[j], node_lat[i], rtol=0, atol=tol)
+
         # South pole: the apex is node 0, with the interior row right after it.
-        if (
-            node_lat.size > w
-            and np.isclose(abs(node_lat[0]), 90.0, atol=tol)
-            and not np.isclose(node_lat[1], node_lat[0], atol=tol)
-        ):
+        # North pole: the apex is the final node, with the interior row before it.
+        at_south = node_lat.size > w and _is_apex(0, 1)
+        at_north = node_lat.size > w and _is_apex(-1, -2)
+        if int(at_south) + int(at_north) != n_collapsed:
+            return node_lon, node_lat, expanded
+
+        if at_south:
             apex_lat = node_lat[0]
             lon_row = node_lon[1 : 1 + w]  # interior row above the apex
             node_lon = np.concatenate([lon_row, node_lon[1:]])
             node_lat = np.concatenate([np.full(w, apex_lat), node_lat[1:]])
             expanded.append("south")
 
-        # North pole: the apex is the final node, with the interior row before it.
-        if (
-            node_lat.size > w
-            and np.isclose(abs(node_lat[-1]), 90.0, atol=tol)
-            and not np.isclose(node_lat[-2], node_lat[-1], atol=tol)
-        ):
+        if at_north:
             apex_lat = node_lat[-1]
             lon_row = node_lon[-1 - w : -1]  # interior row below the apex
             node_lon = np.concatenate([node_lon[:-1], lon_row])
@@ -601,7 +619,7 @@ class SupergridBase:
             # to_esmf_mesh() collapses a pole-coincident edge node row to a single
             # shared node; restore the full row so the reshapes below line up.
             node_lon, node_lat, _ = cls._expand_pole_node_rows(
-                node_lon, node_lat, nx if is_cyclic else nx + 1
+                node_lon, node_lat, nx if is_cyclic else nx + 1, ny + 1
             )
 
         if topology == "tripolar":

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -301,6 +301,46 @@ class SupergridBase:
         return new_node_coords, new_element_conn, collapsed
 
     @staticmethod
+    def _unwrap_lon_rows(qlon):
+        """Remove the [0, 360) branch cut from each row of a q-longitude array.
+
+        ESMF mesh files normalize node longitudes to [0, 360), which puts a
+        discontinuity inside the row whenever the grid's first node column does
+        not sit on the prime meridian -- the ERA5 N640 mesh, for instance, starts
+        at 359.859375 and jumps to 0.140625 in the next column. Such a row cannot
+        be used as a supergrid coordinate: the edge midpoints interpolated from it
+        in :meth:`reconstruct_from_esmf_mesh` land on the far side of the globe,
+        which corrupts the metrics (dx, dy, area) of the cells straddling the cut
+        and can even make their areas negative.
+
+        Adding whole multiples of 360 to the offending entries makes each row
+        monotonic again without moving any point on the sphere. Rows that are
+        already free of a cut are returned bit-for-bit unchanged, so this is a
+        no-op for grids whose node longitudes start at (or near) zero.
+
+        Parameters
+        ----------
+        qlon : np.ndarray, shape (nrows, ncols)
+            Node longitudes in degrees, one logical node row per row.
+
+        Returns
+        -------
+        np.ndarray
+            ``qlon`` with each row made monotonically increasing.
+        """
+
+        unwrapped = np.unwrap(qlon, period=360.0, axis=-1)
+        # np.unwrap pins the first entry and lifts the rest, which would leave a
+        # row that merely started late (ERA5's 359.859375) sitting almost a full
+        # turn high. Drop each row back onto the branch it arrived on so the
+        # reconstructed grid keeps the input's longitude range.
+        turns = np.round(
+            (unwrapped.mean(axis=-1, keepdims=True) - qlon.mean(axis=-1, keepdims=True))
+            / 360.0
+        )
+        return unwrapped - 360.0 * turns
+
+    @staticmethod
     def _expand_pole_node_rows(
         node_lon, node_lat, node_row_width, n_node_rows, tol=1e-10
     ):
@@ -648,19 +688,21 @@ class SupergridBase:
             )
             top_full_lat[nx // 2 + 1 :] = top_stored_lat[nx // 2 - 1 : 0 : -1]
 
-            qlon_inner = np.vstack([rows_except_top_lon, top_full_lon[np.newaxis, :]])
+            qlon_inner = cls._unwrap_lon_rows(
+                np.vstack([rows_except_top_lon, top_full_lon[np.newaxis, :]])
+            )
             qlat_inner = np.vstack([rows_except_top_lat, top_full_lat[np.newaxis, :]])
             # Tripolar grids are periodic in x — add wrap column
             qlon = np.hstack([qlon_inner, qlon_inner[:, :1] + 360.0])
             qlat = np.hstack([qlat_inner, qlat_inner[:, :1]])
         elif is_cyclic:
             # nodes stored without wrap column; add it back by repeating column 0
-            qlon_inner = node_lon.reshape(ny + 1, nx)
+            qlon_inner = cls._unwrap_lon_rows(node_lon.reshape(ny + 1, nx))
             qlat_inner = node_lat.reshape(ny + 1, nx)
             qlon = np.hstack([qlon_inner, qlon_inner[:, :1] + 360.0])
             qlat = np.hstack([qlat_inner, qlat_inner[:, :1]])
         else:
-            qlon = node_lon.reshape(ny + 1, nx + 1)
+            qlon = cls._unwrap_lon_rows(node_lon.reshape(ny + 1, nx + 1))
             qlat = node_lat.reshape(ny + 1, nx + 1)
 
         if return_mask:
@@ -673,6 +715,14 @@ class SupergridBase:
         # --- Recover center (t) points from centerCoords ---
         tlon = ds["centerCoords"].values[:, 0].reshape(ny, nx)
         tlat = ds["centerCoords"].values[:, 1].reshape(ny, nx)
+
+        # Centers are stored normalized to [0, 360) just like the nodes, so shift
+        # each one into the same 360-degree branch as its own four corners (which
+        # _unwrap_lon_rows may have moved). Without this the supergrid mixes
+        # branches, and the degree differences behind dx come out ~360 too large.
+        # A no-op wherever a center already agrees with its corners.
+        qmid = 0.25 * (qlon[:-1, :-1] + qlon[:-1, 1:] + qlon[1:, :-1] + qlon[1:, 1:])
+        tlon = tlon + 360.0 * np.round((qmid - tlon) / 360.0)
 
         # --- Interpolate edge midpoints ---
         # U-points: midpoint of west/east edges (between vertically adjacent corners)

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -650,6 +650,19 @@ class SupergridBase:
         is_cyclic = is_mesh_cyclic_x(ds)
         nx, ny = get_mesh_dimensions(ds)
 
+        # to_esmf_mesh records the topology, but meshes written by other tools (the
+        # CESM tx2_3v3 mesh, for one) carry no such attribute. Read it off the node
+        # count instead of assuming a plain lat-lon layout.
+        inferred_topology = topology is None
+        if inferred_topology:
+            n_nodes = ds["nodeCoords"].shape[0]
+            if not is_cyclic:
+                topology = "non_cyclic"
+            elif nx >= 2 and n_nodes == nx * (ny + 1) - (nx // 2 - 1):
+                topology = "tripolar"
+            else:
+                topology = "cyclic"
+
         # --- Recover corner (q) points from nodeCoords ---
         node_lon = ds["nodeCoords"].values[:, 0]
         node_lat = ds["nodeCoords"].values[:, 1]
@@ -772,6 +785,14 @@ class SupergridBase:
             axis_units,
             grid_type="from_esmf_mesh",
         )
+
+        if inferred_topology and supergrid.is_tripolar != (topology == "tripolar"):
+            raise ValueError(
+                f"Inferred a {topology!r} topology from the mesh's node count, but "
+                f"the reconstructed supergrid reports is_tripolar="
+                f"{supergrid.is_tripolar}. Set a 'grid_topology' global attribute "
+                "on the mesh to state the topology explicitly."
+            )
 
         if not return_mask:
             return supergrid

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -1235,39 +1235,50 @@ def quadrilateral_areas(lat, lon, R=1):
     )
 
 
-def _vertices_coincide(va, vb):
-    """Return a boolean mask of where 3-vectors ``va`` and ``vb`` are the same point."""
+def _central_angle(u, v):
+    """Return the angle between two points on a sphere, seen from its center.
 
-    return np.all(va == vb, axis=-1)
+    ``u`` and ``v`` are 3-vectors and the angle is in radians. This uses atan2
+    rather than the arccosine of a dot product, which loses most of its accuracy
+    when the two points are close together.
+    """
+
+    cross = np.cross(u, v)
+    return np.arctan2(np.sqrt(vecdot(cross, cross)), vecdot(u, v))
 
 
 def spherical_triangle_area(v1, v2, v3):
-    """Return the area of the spherical triangle ``v1``-``v2``-``v3`` (3-vectors),
-    via the excess of its angle sum over pi. A repeated vertex gives zero, not NaN.
+    """Return the area of a triangle on a sphere, given its three corners.
+
+    The corners ``v1``, ``v2`` and ``v3`` are 3-vectors. The area is found with
+    l'Huilier's theorem, which stays accurate however thin the triangle is.
+    If two corners are the same point the triangle has no area, and the result is
+    zero rather than NaN.
     """
 
     R = np.sqrt(vecdot(v1, v1))
 
-    area = (
-        angle_between(v1, v2, v3)
-        + angle_between(v2, v3, v1)
-        + angle_between(v3, v1, v2)
-        - np.pi
-    ) * R**2
+    a = _central_angle(v2, v3)
+    b = _central_angle(v3, v1)
+    c = _central_angle(v1, v2)
+    s = 0.5 * (a + b + c)
 
-    degenerate = (
-        _vertices_coincide(v1, v2)
-        | _vertices_coincide(v2, v3)
-        | _vertices_coincide(v3, v1)
+    tans = (
+        np.tan(0.5 * s)
+        * np.tan(0.5 * (s - a))
+        * np.tan(0.5 * (s - b))
+        * np.tan(0.5 * (s - c))
     )
-    return np.where(degenerate, 0.0, area)
+    # Rounding can leave this product slightly negative for a flat triangle.
+    return 4.0 * np.arctan(np.sqrt(np.maximum(tans, 0.0))) * R**2
 
 
 def quadrilateral_area(v1, v2, v3, v4):
-    """Return the area of a spherical quadrilateral on the unit sphere that
-    has vertices on the 3-vectors ``v1``, ``v2``, ``v3``, ``v4``
-    (counter-clockwise orientation is implied). The area is computed via
-    the excess of the sum of the spherical angles of the quadrilateral from 2π.
+    """Return the area of a four-sided cell on a sphere, given its corners.
+
+    The corners are the 3-vectors ``v1``, ``v2``, ``v3``, ``v4``, taken in
+    counter-clockwise order. The cell is cut along a diagonal and the two
+    triangles are added up (see :func:`spherical_triangle_area`).
 
     Example:
 
@@ -1301,31 +1312,11 @@ def quadrilateral_area(v1, v2, v3, v4):
     ):
         raise ValueError("vectors provided must have the same length")
 
-    R = np.sqrt(vecdot(v1, v1))
-
-    a1 = angle_between(v1, v2, v4)
-    a2 = angle_between(v2, v3, v1)
-    a3 = angle_between(v3, v4, v2)
-    a4 = angle_between(v4, v1, v3)
-
-    area = (a1 + a2 + a3 + a4 - 2 * np.pi) * R**2
-
-    # A repeated vertex (from the tripolar fold seam or a collapsed pole row)
-    # makes the quad a triangle, leaving two angles undefined and the excess NaN.
-    # Redo just those cells; well-formed ones keep their value bit-for-bit.
-    dup12 = _vertices_coincide(v1, v2)
-    dup23 = _vertices_coincide(v2, v3)
-    degenerate = dup12 | dup23 | _vertices_coincide(v3, v4) | _vertices_coincide(v4, v1)
-
-    if np.any(degenerate):
-        area = np.where(degenerate, 0.0, area)  # also drops the NaNs
-        # Drop the duplicate: v1==v2 -> (v1,v3,v4), v2==v3 -> (v1,v2,v4), else (v1,v2,v3).
-        keep2 = np.where(dup12[..., np.newaxis], v3, v2)
-        keep3 = np.where((dup12 | dup23)[..., np.newaxis], v4, v3)
-        area = np.where(degenerate, spherical_triangle_area(v1, keep2, keep3), area)
-
-    # A diagonal repeat leaves no triangle at all.
-    return np.where(_vertices_coincide(v1, v3) | _vertices_coincide(v2, v4), 0.0, area)
+    # Cut the quadrilateral along a diagonal and add the two halves; areas add up
+    # on a sphere just as they do on a plane. Each half is still handled correctly
+    # if the quadrilateral has collapsed into a triangle, which is what a collapsed
+    # pole row and the tripolar fold seam both produce.
+    return spherical_triangle_area(v1, v2, v3) + spherical_triangle_area(v1, v3, v4)
 
 
 def mom6_angle_calculation_method(

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -1127,9 +1127,11 @@ def angle_between(v1, v2, v3):
     norm_v1xv2 = np.sqrt(vecdot(v1xv2, v1xv2))
     norm_v1xv3 = np.sqrt(vecdot(v1xv3, v1xv3))
 
-    cosangle = vecdot(v1xv2, v1xv3) / (norm_v1xv2 * norm_v1xv3)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        cosangle = vecdot(v1xv2, v1xv3) / (norm_v1xv2 * norm_v1xv3)
 
-    return np.arccos(cosangle)
+    # Thin cells can push the cosine a few ulps out of range; arccos would NaN.
+    return np.arccos(np.clip(cosangle, -1.0, 1.0))
 
 
 def vecdot(v1, v2):
@@ -1233,6 +1235,34 @@ def quadrilateral_areas(lat, lon, R=1):
     )
 
 
+def _vertices_coincide(va, vb):
+    """Return a boolean mask of where 3-vectors ``va`` and ``vb`` are the same point."""
+
+    return np.all(va == vb, axis=-1)
+
+
+def spherical_triangle_area(v1, v2, v3):
+    """Return the area of the spherical triangle ``v1``-``v2``-``v3`` (3-vectors),
+    via the excess of its angle sum over pi. A repeated vertex gives zero, not NaN.
+    """
+
+    R = np.sqrt(vecdot(v1, v1))
+
+    area = (
+        angle_between(v1, v2, v3)
+        + angle_between(v2, v3, v1)
+        + angle_between(v3, v1, v2)
+        - np.pi
+    ) * R**2
+
+    degenerate = (
+        _vertices_coincide(v1, v2)
+        | _vertices_coincide(v2, v3)
+        | _vertices_coincide(v3, v1)
+    )
+    return np.where(degenerate, 0.0, area)
+
+
 def quadrilateral_area(v1, v2, v3, v4):
     """Return the area of a spherical quadrilateral on the unit sphere that
     has vertices on the 3-vectors ``v1``, ``v2``, ``v3``, ``v4``
@@ -1278,7 +1308,24 @@ def quadrilateral_area(v1, v2, v3, v4):
     a3 = angle_between(v3, v4, v2)
     a4 = angle_between(v4, v1, v3)
 
-    return (a1 + a2 + a3 + a4 - 2 * np.pi) * R**2
+    area = (a1 + a2 + a3 + a4 - 2 * np.pi) * R**2
+
+    # A repeated vertex (from the tripolar fold seam or a collapsed pole row)
+    # makes the quad a triangle, leaving two angles undefined and the excess NaN.
+    # Redo just those cells; well-formed ones keep their value bit-for-bit.
+    dup12 = _vertices_coincide(v1, v2)
+    dup23 = _vertices_coincide(v2, v3)
+    degenerate = dup12 | dup23 | _vertices_coincide(v3, v4) | _vertices_coincide(v4, v1)
+
+    if np.any(degenerate):
+        area = np.where(degenerate, 0.0, area)  # also drops the NaNs
+        # Drop the duplicate: v1==v2 -> (v1,v3,v4), v2==v3 -> (v1,v2,v4), else (v1,v2,v3).
+        keep2 = np.where(dup12[..., np.newaxis], v3, v2)
+        keep3 = np.where((dup12 | dup23)[..., np.newaxis], v4, v3)
+        area = np.where(degenerate, spherical_triangle_area(v1, keep2, keep3), area)
+
+    # A diagonal repeat leaves no triangle at all.
+    return np.where(_vertices_coincide(v1, v3) | _vertices_coincide(v2, v4), 0.0, area)
 
 
 def mom6_angle_calculation_method(

--- a/mom6_forge/grid.py
+++ b/mom6_forge/grid.py
@@ -357,11 +357,12 @@ class Grid:
 
         Parameters
         ----------
-        supergrid : SupergridBase
-            Supergrid to check if tripolar.
+        supergrid : xr.Dataset or xr.DataArray or np.array or SupergridBase
+            Supergrid to check if tripolar. Anything carrying a 2D ``x``
+            coordinate array will do, matching is_cyclic_x above.
         """
 
-        return supergrid.is_tripolar
+        return SupergridBase.x_is_tripolar(supergrid.x)
 
     def is_rectangular(self, atol=1e-3) -> bool:
         """Check if the grid is a rectangular lat-lon grid by comparing the

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -2040,6 +2040,78 @@ class Topo:
             format="NETCDF3_64BIT",
         )
 
+    @staticmethod
+    def _collapse_pole_node_rows(
+        node_coords, element_conn, node_row_width, start_index=1, tol=1e-10
+    ):
+        """Collapse a full coincident pole node row into a single shared node.
+
+        When a logically-rectangular lat-lon grid reaches a geographic pole, the
+        first (south) or last (north) node row consists of nodes that are
+        geometrically the same point (lat = -90 or +90) but carry distinct
+        longitudes. ESMF treats these as separate coincident nodes, which defeats
+        its pole-aware regridding (e.g. POLEMETHOD_ALLAVG). This helper merges such
+        a row into one shared node and remaps the element connectivity accordingly.
+        Affected cells keep four connectivity entries (degenerate quads with a
+        repeated apex), so ``numElementConn`` stays 4.
+
+        Parameters
+        ----------
+        node_coords : np.ndarray, shape (nnodes, 2)
+            Node (lon, lat) coordinates in degrees, row-major (south row first).
+        element_conn : np.ndarray, shape (ncells, maxNodePElement)
+            Element connectivity using ``start_index``-based node ids.
+        node_row_width : int
+            Number of nodes per logical row (``nx`` for cyclic, ``nx+1`` otherwise).
+        start_index : int, optional
+            Base index of ``element_conn`` (1 for ESMF meshes). Default 1.
+        tol : float, optional
+            Absolute tolerance (degrees) for detecting nodes at a pole. Default 1e-10.
+
+        Returns
+        -------
+        new_node_coords : np.ndarray
+            Node table with the redundant pole-row nodes removed.
+        new_element_conn : np.ndarray
+            Connectivity remapped onto ``new_node_coords`` (same dtype/start_index).
+        collapsed : list of (str, int)
+            One ``(pole_name, n_merged)`` entry per pole that was collapsed; empty
+            if neither edge row lies on a pole (i.e. this was a no-op).
+        """
+
+        lat = node_coords[:, 1]
+        nnodes = node_coords.shape[0]
+        remap = np.arange(nnodes)  # old idx -> representative old idx
+        keep = np.ones(nnodes, dtype=bool)
+        collapsed = []
+
+        south_row = np.arange(0, node_row_width)
+        north_row = np.arange(nnodes - node_row_width, nnodes)
+        for row, pole_val, name in (
+            (south_row, -90.0, "south"),
+            (north_row, 90.0, "north"),
+        ):
+            # Only collapse when the *whole* edge row sits on the pole.
+            if row.size > 1 and np.all(np.isclose(lat[row], pole_val, atol=tol)):
+                rep = row[0]  # keep the first node of the fan
+                remap[row] = rep
+                keep[row[1:]] = False
+                collapsed.append((name, int(row.size)))
+
+        if not collapsed:
+            return node_coords, element_conn, []
+
+        # Compact the kept nodes and build an old->new index map.
+        old_to_new = np.cumsum(keep) - 1  # new 0-based index for kept nodes
+        final_old_to_new = old_to_new[remap]  # collapsed nodes -> their rep's new index
+
+        new_node_coords = node_coords[keep]
+        conn0 = element_conn - start_index
+        new_element_conn = (final_old_to_new[conn0] + start_index).astype(element_conn.dtype)
+
+        return new_node_coords, new_element_conn, collapsed
+
+
     def write_esmf_mesh(self, file_path, title=None):
         """
         Write the ESMF mesh file
@@ -2090,6 +2162,11 @@ class Topo:
 
         i0 = 1  # start index for node id's
 
+        # Width of a logical node row, set per branch. Left None for the tripolar
+        # branch to disable collapse (its folded north seam has bespoke connectivity
+        # that must not be touched); the cyclic / non-cyclic branches set it.
+        pole_node_row_width = None
+
         if self._grid.is_tripolar(self._grid._supergrid):
             nx, ny = self._grid.nx, self._grid.ny
             qlon_flat = self._grid.qlon.data[:, :-1].flatten()[: -(nx // 2 - 1)]
@@ -2131,6 +2208,7 @@ class Topo:
             qlat_flat = self._grid.qlat.data[:, :-1].flatten()
             nnodes = len(qlon_flat)
             assert nnodes == nx * (ny + 1)
+            pole_node_row_width = nx
 
             # Below returns element connectivity of i-th element
             # (assuming 0 based node and element indexing)
@@ -2147,6 +2225,7 @@ class Topo:
             qlat_flat = self._grid.qlat.data.flatten()
             nnodes = len(qlon_flat)
             assert nnodes == (nx + 1) * (ny + 1)
+            pole_node_row_width = nx + 1
 
             # Below returns element connectivity of i-th element
             # (assuming 0 based node and element indexing)
@@ -2157,14 +2236,37 @@ class Topo:
                 i0 + i % nx + (i // nx + 1) * (nx + 1),
             ]
 
+        node_coords = np.column_stack((qlon_flat, qlat_flat))
+        element_conn = np.array(
+            [get_element_conn(i) for i in range(ncells)]
+        ).astype(np.int32)
+
+        # Collapse a pole-coincident edge node row to a single shared node (needed
+        # by ESMF). A no-op unless a full edge row lies on a pole; skipped entirely
+        # for tripolar grids (width is None).
+        if pole_node_row_width is not None:
+            node_coords, element_conn, collapsed = Topo._collapse_pole_node_rows(
+                node_coords, element_conn, pole_node_row_width, start_index=i0
+            )
+            for name, n_merged in collapsed:
+                print(
+                    f"Collapsed {n_merged} coincident {name}-pole nodes into a "
+                    "single shared node (for ESMF pole detection)."
+                )
+            if collapsed:
+                ds.attrs["history"] = (
+                    f"{datetime.now().isoformat()}: collapsed pole node rows to "
+                    "a single node per pole for ESMF pole detection"
+                )
+
         ds["nodeCoords"] = xr.DataArray(
-            np.column_stack((qlon_flat, qlat_flat)),
+            node_coords,
             dims=["nodeCount", "coordDim"],
             attrs={"units": coord_units},
         )
 
         ds["elementConn"] = xr.DataArray(
-            np.array([get_element_conn(i) for i in range(ncells)]).astype(np.int32),
+            element_conn,
             dims=["elementCount", "maxNodePElement"],
             attrs={
                 "long_name": "Node indices that define the element connectivity",

--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -2107,10 +2107,11 @@ class Topo:
 
         new_node_coords = node_coords[keep]
         conn0 = element_conn - start_index
-        new_element_conn = (final_old_to_new[conn0] + start_index).astype(element_conn.dtype)
+        new_element_conn = (final_old_to_new[conn0] + start_index).astype(
+            element_conn.dtype
+        )
 
         return new_node_coords, new_element_conn, collapsed
-
 
     def write_esmf_mesh(self, file_path, title=None):
         """
@@ -2237,9 +2238,9 @@ class Topo:
             ]
 
         node_coords = np.column_stack((qlon_flat, qlat_flat))
-        element_conn = np.array(
-            [get_element_conn(i) for i in range(ncells)]
-        ).astype(np.int32)
+        element_conn = np.array([get_element_conn(i) for i in range(ncells)]).astype(
+            np.int32
+        )
 
         # Collapse a pole-coincident edge node row to a single shared node (needed
         # by ESMF). A no-op unless a full edge row lies on a pole; skipped entirely

--- a/tests/test_esmf_pole_collapse.py
+++ b/tests/test_esmf_pole_collapse.py
@@ -107,9 +107,29 @@ def test_collapse_is_noop(south_lats, north_lats):
 @pytest.mark.parametrize(
     "kw, width, collapses",
     [
-        (dict(nx=8, ny=6, lenx=360.0, leny=180.0, ystart=-90.0, cyclic_x=True), 8, True),
-        (dict(nx=8, ny=6, lenx=180.0, leny=180.0, xstart=0.0, ystart=-90.0, cyclic_x=False), 9, True),
-        (dict(nx=8, ny=6, lenx=360.0, leny=120.0, ystart=-60.0, cyclic_x=True), 8, False),
+        (
+            dict(nx=8, ny=6, lenx=360.0, leny=180.0, ystart=-90.0, cyclic_x=True),
+            8,
+            True,
+        ),
+        (
+            dict(
+                nx=8,
+                ny=6,
+                lenx=180.0,
+                leny=180.0,
+                xstart=0.0,
+                ystart=-90.0,
+                cyclic_x=False,
+            ),
+            9,
+            True,
+        ),
+        (
+            dict(nx=8, ny=6, lenx=360.0, leny=120.0, ystart=-60.0, cyclic_x=True),
+            8,
+            False,
+        ),
     ],
     ids=["cyclic_pole", "noncyclic_pole", "midlatitude_noop"],
 )

--- a/tests/test_esmf_pole_collapse.py
+++ b/tests/test_esmf_pole_collapse.py
@@ -1,0 +1,158 @@
+"""Tests for the pole-node-row collapse in ``Topo.write_esmf_mesh``.
+
+When a regular lat-lon grid reaches a pole, its first/last node row is a fan
+of nodes all at lat ±90 (distinct longitudes). ESMF treats these as separate
+coincident nodes, defeating its pole-aware regridding. ``write_esmf_mesh``
+collapses such a *full* edge row into a single shared node per pole.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from mom6_forge.grid import Grid
+from mom6_forge.topo import Topo
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _make_topo(**grid_kwargs):
+    grid = Grid(**grid_kwargs)
+    return grid, Topo(grid, min_depth=10.0, git=False)
+
+
+def _nodes_two_rows(width, south_lats, north_lats):
+    """Build a row-major (lon, lat) node table of two rows of ``width`` nodes."""
+    lon = np.linspace(0.0, 360.0, width, endpoint=False)
+    nc = np.empty((2 * width, 2))
+    nc[:width, 0] = lon
+    nc[width:, 0] = lon
+    nc[:width, 1] = south_lats
+    nc[width:, 1] = north_lats
+    return nc
+
+
+# A 4-cell connectivity (1-based) over a 2-row, 4-wide node table; the last cell
+# wraps so that every one of the 8 nodes is referenced.
+_CONN_1BASED = np.array(
+    [[1, 2, 6, 5], [2, 3, 7, 6], [3, 4, 8, 7], [4, 1, 5, 8]], dtype=np.int32
+)
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests of the staticmethod
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "south_lats, north_lats, expected, start_index",
+    [
+        ([-80] * 4, [90] * 4, [("north", 4)], 1),
+        ([-90] * 4, [80] * 4, [("south", 4)], 1),
+        ([-90] * 4, [90] * 4, [("south", 4), ("north", 4)], 1),
+        ([-90] * 4, [90] * 4, [("south", 4), ("north", 4)], 0),  # 0-based conn
+    ],
+    ids=["north", "south", "both", "both_start0"],
+)
+def test_collapse_fires(south_lats, north_lats, expected, start_index):
+    """Full pole rows collapse; node count, connectivity range, dtype, and
+    resolved corner geometry are all preserved."""
+    nc = _nodes_two_rows(4, south_lats, north_lats)
+    conn = _CONN_1BASED - (1 - start_index)  # shift base to start_index
+    new_nc, new_conn, collapsed = Topo._collapse_pole_node_rows(
+        nc, conn, node_row_width=4, start_index=start_index
+    )
+
+    assert collapsed == expected
+    # each collapsed fan of n nodes -> 1, i.e. removes (n-1) nodes
+    removed = sum(n - 1 for _, n in expected)
+    assert new_nc.shape[0] == nc.shape[0] - removed
+    # exactly one shared node remains at each collapsed pole
+    for name, _ in expected:
+        pole = 90.0 if name == "north" else -90.0
+        assert int(np.isclose(new_nc[:, 1], pole).sum()) == 1
+    # connectivity stays in range, keeps dtype/base, and resolves to identical
+    # corner coordinates (latitude exact; longitude only matters off the pole)
+    assert new_conn.dtype == conn.dtype
+    assert new_conn.min() >= start_index
+    assert new_conn.max() <= start_index + new_nc.shape[0] - 1
+    before = nc[conn - start_index]
+    after = new_nc[new_conn - start_index]
+    assert np.allclose(before[..., 1], after[..., 1])
+    nonpole = ~np.isclose(np.abs(before[..., 1]), 90.0)
+    assert np.allclose(before[..., 0][nonpole], after[..., 0][nonpole])
+
+
+@pytest.mark.parametrize(
+    "south_lats, north_lats",
+    [
+        ([-80] * 4, [90, 90, 90, 89.9]),  # partial edge row
+        ([-80, 90, -80, -80], [80] * 4),  # stray interior pole node
+        ([-40] * 4, [40] * 4),  # no pole at all
+    ],
+    ids=["partial_row", "stray_node", "no_pole"],
+)
+def test_collapse_is_noop(south_lats, north_lats):
+    """Anything short of a *full* edge row on the pole leaves the mesh intact."""
+    nc = _nodes_two_rows(4, south_lats, north_lats)
+    conn = _CONN_1BASED.copy()
+    new_nc, new_conn, collapsed = Topo._collapse_pole_node_rows(nc, conn, 4)
+    assert collapsed == []
+    assert new_nc.shape == nc.shape
+    assert np.array_equal(new_conn, conn)
+
+
+# --------------------------------------------------------------------------- #
+# Integration tests through write_esmf_mesh
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "kw, width, collapses",
+    [
+        (dict(nx=8, ny=6, lenx=360.0, leny=180.0, ystart=-90.0, cyclic_x=True), 8, True),
+        (dict(nx=8, ny=6, lenx=180.0, leny=180.0, xstart=0.0, ystart=-90.0, cyclic_x=False), 9, True),
+        (dict(nx=8, ny=6, lenx=360.0, leny=120.0, ystart=-60.0, cyclic_x=True), 8, False),
+    ],
+    ids=["cyclic_pole", "noncyclic_pole", "midlatitude_noop"],
+)
+def test_write_esmf_mesh_pole_handling(tmp_path, kw, width, collapses):
+    nx, ny = kw["nx"], kw["ny"]
+    grid, topo = _make_topo(name="g", **kw)
+    p = str(tmp_path / "mesh.nc")
+    topo.write_esmf_mesh(p)
+    m = xr.open_dataset(p)
+
+    conn = m.elementConn.values.astype(int)
+    assert conn.min() >= 1 and conn.max() <= m.sizes["nodeCount"]
+    assert set(np.unique(m.numElementConn.values)) == {4}
+    # geometry comes from the grid and must be untouched by any collapse
+    assert np.allclose(m.centerCoords.values[:, 0], grid.tlon.data.flatten())
+    assert np.allclose(m.elementArea.values, grid.tarea.data.flatten())
+
+    if collapses:
+        # one shared node per pole: nodeCount = width*(ny+1) - 2*(width-1)
+        assert m.sizes["nodeCount"] == width * (ny + 1) - 2 * (width - 1)
+        assert int(np.isclose(m.nodeCoords.values[:, 1], 90).sum()) == 1
+        assert int(np.isclose(m.nodeCoords.values[:, 1], -90).sum()) == 1
+        assert "history" in m.attrs
+        # south apex repeated in the first cell, north apex in a top-row cell
+        assert conn[0][0] == conn[0][1]
+        assert conn[(ny - 1) * nx][2] == conn[(ny - 1) * nx][3]
+    else:
+        assert m.sizes["nodeCount"] == nx * (ny + 1)  # uncollapsed
+        assert "history" not in m.attrs
+
+
+def test_tripolar_branch_skips_collapse(tmp_path, monkeypatch):
+    """A pole-reaching grid forced down the tripolar branch must NOT collapse
+    (the collapse would otherwise fire), since tripolar grids fold the north
+    seam with their own connectivity."""
+    grid, topo = _make_topo(
+        nx=8, ny=6, lenx=360.0, leny=180.0, ystart=-90.0, cyclic_x=True, name="tri"
+    )
+    monkeypatch.setattr(Grid, "is_tripolar", staticmethod(lambda supergrid: True))
+    p = str(tmp_path / "mesh.nc")
+    topo.write_esmf_mesh(p)
+    m = xr.open_dataset(p)
+
+    assert "history" not in m.attrs  # collapse skipped
+    conn = m.elementConn.values.astype(int)
+    assert conn.min() >= 1 and conn.max() <= m.sizes["nodeCount"]

--- a/tests/test_supergrid.py
+++ b/tests/test_supergrid.py
@@ -407,3 +407,37 @@ def test_tripolar_roundtrip(tripolar_sg, tmp_path):
     np.testing.assert_array_equal(sg2.y[::2, ::2], tripolar_sg.y[::2, ::2])
     np.testing.assert_array_equal(sg2.x[1::2, 1::2], tripolar_sg.x[1::2, 1::2])
     np.testing.assert_array_equal(sg2.y[1::2, 1::2], tripolar_sg.y[1::2, 1::2])
+
+
+# --------------------------------------------------------------------------- #
+# Degenerate (triangular) quadrilaterals
+# --------------------------------------------------------------------------- #
+def test_quadrilateral_area_with_repeated_vertex_is_triangle_area():
+    """A quad with a doubled vertex is a spherical triangle, not a NaN.
+
+    The tripolar fold seam and a collapsed pole row both produce coincident nodes.
+    """
+    R = 6371e3
+    v1 = latlon_to_cartesian(0, 0, R)
+    v2 = latlon_to_cartesian(0, 90, R)
+    v3 = latlon_to_cartesian(90, 0, R)
+    octant = 4 * np.pi * R**2 / 8
+
+    for quad in [
+        (v1, v2, v3, v3),
+        (v1, v1, v2, v3),
+        (v1, v2, v2, v3),
+        (v1, v2, v3, v1),
+    ]:
+        np.testing.assert_allclose(quadrilateral_area(*quad), octant, rtol=1e-12)
+
+
+def test_quadrilateral_areas_no_nan_with_collapsed_row():
+    """A grid row collapsed to a single point yields finite, non-negative areas."""
+    lat = np.array([[0.0, 0.0, 0.0], [30.0, 30.0, 30.0], [90.0, 90.0, 90.0]])
+    lon = np.array([[0.0, 60.0, 120.0], [0.0, 60.0, 120.0], [0.0, 0.0, 0.0]])
+
+    areas = quadrilateral_areas(lat, lon, 6371e3)
+
+    assert np.all(np.isfinite(areas))
+    assert np.all(areas >= 0)

--- a/tests/test_supergrid.py
+++ b/tests/test_supergrid.py
@@ -368,6 +368,31 @@ def test_tripolar_mesh_matches_reference(tripolar_mesh, reference_tripolar_mesh)
     np.testing.assert_allclose(our_area_sum, ref_area_sum, rtol=1e-4)
 
 
+@pytest.mark.parametrize(
+    "mesh_fixture", ["cyclic_mesh", "non_cyclic_mesh", "tripolar_mesh"]
+)
+def test_reconstruct_infers_missing_grid_topology(mesh_fixture, request):
+    """A mesh lacking grid_topology, as ESMF meshes from other tools are,
+    reconstructs the same as one carrying it."""
+    mesh = request.getfixturevalue(mesh_fixture)
+    expected = SupergridBase.reconstruct_from_esmf_mesh(mesh)
+
+    stripped = mesh.copy()
+    del stripped.attrs["grid_topology"]
+    inferred = SupergridBase.reconstruct_from_esmf_mesh(stripped)
+
+    np.testing.assert_array_equal(inferred.x, expected.x)
+    np.testing.assert_array_equal(inferred.y, expected.y)
+
+
+def test_reconstruct_rejects_mis_inferred_topology(tripolar_mesh):
+    """A node count matching no layout is caught, not reshaped on regardless."""
+    mesh = tripolar_mesh.copy().isel(nodeCount=slice(None, -1))
+    del mesh.attrs["grid_topology"]
+    with pytest.raises((ValueError, AssertionError)):
+        SupergridBase.reconstruct_from_esmf_mesh(mesh)
+
+
 def test_tripolar_roundtrip(tripolar_sg, tmp_path):
     """reconstruct_from_esmf_mesh should recover corner and center coords exactly for tx2_3v3."""
     path = tmp_path / "tripolar.nc"

--- a/tests/test_supergrid.py
+++ b/tests/test_supergrid.py
@@ -441,3 +441,36 @@ def test_quadrilateral_areas_no_nan_with_collapsed_row():
 
     assert np.all(np.isfinite(areas))
     assert np.all(areas >= 0)
+
+
+def test_quadrilateral_area_of_sliver():
+    """A very thin cell still gets an accurate, positive area.
+
+    The old formula added up the four corner angles and subtracted 2*pi, which
+    loses all its precision on the sliver-shaped cells along a tripolar fold and
+    used to hand back large negative areas for them.
+    """
+    R = 6371e3
+    lat1, lat2, lon1, dlon = 49.7, 49.72, -287.0, 1e-9
+    corner = lambda la, lo: np.array(latlon_to_cartesian(la, lo, R))
+
+    # a spherical rectangle's area is known exactly
+    exact = (
+        R**2 * np.deg2rad(dlon) * (np.sin(np.deg2rad(lat2)) - np.sin(np.deg2rad(lat1)))
+    )
+    area = quadrilateral_area(
+        corner(lat1, lon1),
+        corner(lat1, lon1 + dlon),
+        corner(lat2, lon1 + dlon),
+        corner(lat2, lon1),
+    )
+    np.testing.assert_allclose(area, exact, rtol=1e-3)
+
+    # a sub-cell taken from the tx2_3v3 Arctic fold, which computed as -2.1e12
+    fold_cell = [
+        (49.701392, -287.0),
+        (49.720101, -286.792302),
+        (49.720127, -286.791940),
+        (49.710161, -287.0),
+    ]
+    assert quadrilateral_area(*[corner(la, lo) for la, lo in fold_cell]) > 0


### PR DESCRIPTION
ESMF meshes written by `write_esmf_mesh` for regular lat lon grids contained coincident pole nodes (nx distinct nodes all at 90 N and S), which breaks ESMF pole-aware regridding (POLEMETHOD_ALLAVG). `write_esmf_mesh` now collapses each such pole row to a single shared node automatically, producing the topology ESMF expects.