### PR TITLE
Expose calendar as an argument in interpolate_and_fill_seawifs

### DIFF
--- a/mom6_forge/chl.py
+++ b/mom6_forge/chl.py
@@ -15,11 +15,10 @@ def interpolate_and_fill_seawifs(
     topo: Topo,
     processed_seawifs_path: Path | str,
     output_path: Path | str = None,
+    calendar: str = "NOLEAP",
 ):
     """
     Interpolate and fill SeaWiFS chlorophyll data to a model grid and save to NetCDF.
-
-    This function assumes a NO_LEAP calendar.
 
     This function takes gridded SeaWiFS chlorophyll data, interpolates it onto a
     super-sampled model grid, applies ocean masking, fills missing values, and writes
@@ -38,6 +37,8 @@ def interpolate_and_fill_seawifs(
     output_path : Path or str, optional
         Path to save the output NetCDF file. If not provided, it is created in the same
         directory as `processed_seawifs_path` using the grid name.
+    calendar : str, optional
+        CF calendar attribute to write on the output time coordinate. Default is "NOLEAP".
 
     Returns
     -------
@@ -83,6 +84,7 @@ def interpolate_and_fill_seawifs(
         grid.tlon[int(grid.ny / 2), :].values,
         grid.tlat[:, int(grid.nx / 2)].values,
         fill_value,
+        calendar=calendar,
     )
     chlor_a = chla["CHL_A"]
 
@@ -154,11 +156,11 @@ def interpolate_and_fill_seawifs(
     return chla
 
 
-def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, no_leap=True):
+def gen_chl_empty_dataset(
+    output_path, lon, lat, fill_value=-1.0e34, no_leap=True, calendar="NOLEAP"
+):
     """
     Generate an empty NetCDF dataset for SeaWiFS chlorophyll climatology and save it to disk.
-
-    This function assumes a NO_LEAP calendar.
 
     This function creates a synthetic xarray dataset with a CHL_A variable (monthly mean chlorophyll)
     initialized entirely with fill values. The dataset uses the provided longitude and latitude
@@ -174,6 +176,9 @@ def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, no_leap=Tru
 
     lat : array-like
         1D array of latitude values (in degrees north) defining the spatial Y-axis.
+
+    calendar : str, optional
+        CF calendar attribute to write on the TIME coordinate. Default is "NOLEAP".
 
     Returns
     -------
@@ -230,7 +235,7 @@ def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, no_leap=Tru
                 dims="TIME",
                 attrs={
                     "units": "days since 0001-01-01 00:00:00",
-                    "calendar": "NOLEAP",
+                    "calendar": calendar,
                     "modulo": " ",
                     "axis": "T",
                     "cartesian_axis": "T",

--- a/mom6_forge/chl.py
+++ b/mom6_forge/chl.py
@@ -15,7 +15,7 @@ def interpolate_and_fill_seawifs(
     topo: Topo,
     processed_seawifs_path: Path | str,
     output_path: Path | str = None,
-    calendar: str = "NOLEAP",
+    calendar: str = "noleap",
 ):
     """
     Interpolate and fill SeaWiFS chlorophyll data to a model grid and save to NetCDF.
@@ -38,7 +38,8 @@ def interpolate_and_fill_seawifs(
         Path to save the output NetCDF file. If not provided, it is created in the same
         directory as `processed_seawifs_path` using the grid name.
     calendar : str, optional
-        CF calendar attribute to write on the output time coordinate. Default is "NOLEAP".
+        Calendar the output time axis is built for, case-insensitive. Default is
+        "noleap". See `gen_chl_empty_dataset`.
 
     Returns
     -------
@@ -156,9 +157,7 @@ def interpolate_and_fill_seawifs(
     return chla
 
 
-def gen_chl_empty_dataset(
-    output_path, lon, lat, fill_value=-1.0e34, no_leap=True, calendar="NOLEAP"
-):
+def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, calendar="noleap"):
     """
     Generate an empty NetCDF dataset for SeaWiFS chlorophyll climatology and save it to disk.
 
@@ -178,7 +177,9 @@ def gen_chl_empty_dataset(
         1D array of latitude values (in degrees north) defining the spatial Y-axis.
 
     calendar : str, optional
-        CF calendar attribute to write on the TIME coordinate. Default is "NOLEAP".
+        Calendar the TIME axis is built for, case-insensitive. One of "noleap",
+        "no_leap", "365_day", "365_days", "gregorian" or "standard"; anything
+        else raises ``NotImplementedError``. Default is "noleap".
 
     Returns
     -------
@@ -189,21 +190,42 @@ def gen_chl_empty_dataset(
     -----
     - The CHL_A variable is filled with the placeholder value -1e34.
     - The TIME dimension is fixed and marked as unlimited in the NetCDF file.
-    - TIME values represent the approximate midpoint of each month in a climatological year.
+    - TIME values are the midpoint of each month in a climatological year of the
+      requested calendar, so the axis and the calendar attribute agree.
     - This dataset structure mimics that of SeaWiFS chlorophyll climatology products and is intended
       as a template or placeholder.
     """
 
     # === Coordinates ===
 
-    if no_leap:
-        time = np.array(
-            [15.5, 45, 74.5, 105, 135.5, 166, 196.5, 227.5, 258, 288.5, 319, 349.5]
+    # Maps the calendar name the caller passes to the attribute to stamp on the
+    # file and the month lengths the axis spans. FMS's get_cal_time() rejects
+    # CF's "standard", so it is taken as an alias and written as "gregorian".
+    # gregorian shares noleap's month lengths because FMS maps this single
+    # climatological year onto year 0001 -- a common year -- and cycles it by
+    # calendar date, so leap days are handled model-side, not by this axis.
+    months_365 = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    supported_calendars = {
+        "noleap": ("noleap", months_365),
+        "no_leap": ("noleap", months_365),
+        "365_day": ("365_day", months_365),
+        "365_days": ("365_days", months_365),
+        "gregorian": ("gregorian", months_365),
+        "standard": ("gregorian", months_365),
+    }
+
+    key = str(calendar).strip().lower()
+    if key not in supported_calendars:
+        raise NotImplementedError(
+            f"Calendar {calendar!r} is not supported for chlorophyll output. "
+            f"Supported calendars are: {', '.join(sorted(supported_calendars))}."
         )
-    else:
-        time = np.array(
-            [15.5, 45.5, 75.5, 106, 136.5, 167, 197.5, 228.5, 259, 289.5, 320, 350.5]
-        )
+    calendar_attr, month_lengths = supported_calendars[key]
+
+    # Midpoint of each month, in days since the start of the climatological year.
+    month_lengths = np.array(month_lengths, dtype=float)
+    month_starts = np.concatenate(([0.0], np.cumsum(month_lengths)[:-1]))
+    time = month_starts + month_lengths / 2.0
 
     # === Placeholder data for CHL_A (all fill values) ===
     fill_value = np.float32(-1.0e34)
@@ -235,7 +257,7 @@ def gen_chl_empty_dataset(
                 dims="TIME",
                 attrs={
                     "units": "days since 0001-01-01 00:00:00",
-                    "calendar": calendar,
+                    "calendar": calendar_attr,
                     "modulo": " ",
                     "axis": "T",
                     "cartesian_axis": "T",

--- a/mom6_forge/chl.py
+++ b/mom6_forge/chl.py
@@ -176,6 +176,10 @@ def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, calendar="n
     lat : array-like
         1D array of latitude values (in degrees north) defining the spatial Y-axis.
 
+    fill_value : float, optional
+        Placeholder value CHL_A is initialized with, and the value written as its
+        ``missing_value`` attribute. Default is -1e34.
+
     calendar : str, optional
         Calendar the TIME axis is built for, case-insensitive. One of "noleap",
         "no_leap", "365_day", "365_days", "gregorian" or "standard"; anything
@@ -188,7 +192,7 @@ def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, calendar="n
 
     Notes
     -----
-    - The CHL_A variable is filled with the placeholder value -1e34.
+    - The CHL_A variable is filled entirely with ``fill_value``.
     - The TIME dimension is fixed and marked as unlimited in the NetCDF file.
     - TIME values are the midpoint of each month in a climatological year of the
       requested calendar, so the axis and the calendar attribute agree.
@@ -228,8 +232,8 @@ def gen_chl_empty_dataset(output_path, lon, lat, fill_value=-1.0e34, calendar="n
     time = month_starts + month_lengths / 2.0
 
     # === Placeholder data for CHL_A (all fill values) ===
-    fill_value = np.float32(-1.0e34)
-    chl_a_data = np.empty((len(time), len(lat), len(lon)), dtype=np.float32)
+    fill_value = np.float32(fill_value)
+    chl_a_data = np.full((len(time), len(lat), len(lon)), fill_value, dtype=np.float32)
 
     # === xarray Dataset ===
     ds = xr.Dataset(

--- a/tests/test_chl.py
+++ b/tests/test_chl.py
@@ -1,6 +1,6 @@
 from mom6_forge.grid import Grid
 from mom6_forge.topo import Topo
-from mom6_forge.chl import interpolate_and_fill_seawifs
+from mom6_forge.chl import gen_chl_empty_dataset, interpolate_and_fill_seawifs
 import pytest
 import os
 from utils import on_cisl_machine
@@ -28,3 +28,32 @@ def test_chl(tmp_path, get_rect_grid):
     )
 
     assert os.path.exists(tmp_path / "seawifs-clim-1997-2010-pan-xesmf.nc")
+
+
+@pytest.mark.parametrize(
+    "calendar, expected_attr",
+    [
+        ("noleap", "noleap"),
+        ("NOLEAP", "noleap"),
+        ("365_day", "365_day"),
+        ("gregorian", "gregorian"),
+        ("standard", "gregorian"),  # CF's name for gregorian; FMS rejects "standard"
+    ],
+)
+def test_chl_empty_dataset_calendar(calendar, expected_attr):
+    """The calendar attribute is normalized to a name FMS accepts, and the TIME
+    axis is the month midpoints of that calendar's climatological year."""
+    ds = gen_chl_empty_dataset(None, [0.0, 1.0], [0.0, 1.0], calendar=calendar)
+
+    assert ds.TIME.attrs["calendar"] == expected_attr
+    assert ds.TIME.values == pytest.approx(
+        [15.5, 45, 74.5, 105, 135.5, 166, 196.5, 227.5, 258, 288.5, 319, 349.5]
+    )
+
+
+@pytest.mark.parametrize("calendar", ["all_leap", "366_day", "360_day", "julian"])
+def test_chl_empty_dataset_unsupported_calendar(calendar):
+    """Calendars we cannot yet build a matching TIME axis for are rejected rather
+    than silently given a 365-day axis."""
+    with pytest.raises(NotImplementedError, match="not supported"):
+        gen_chl_empty_dataset(None, [0.0, 1.0], [0.0, 1.0], calendar=calendar)


### PR DESCRIPTION
The chlorophyll climatology output hardcoded a NOLEAP calendar attribute, which is inconsistent when CrocoDash wants to match the calendar of the selected ocean forcing product.