### PR TITLE
Add boundaries to WW3 Mapsta file.

### DIFF
--- a/mom6_forge/topo.py
+++ b/mom6_forge/topo.py
@@ -1997,6 +1997,50 @@ class Topo:
             format="NETCDF3_64BIT",
         )
 
+    def _compute_ww3_mapsta(self):
+        """
+        Compute the WW3 mapsta status-code array for this grid.
+
+        Status codes follow WW3's convention: 0 = land, 1 = interior sea
+        point, 2 = active boundary point. Ocean cells on the grid perimeter
+        are flagged as active boundary points; ww3_grid promotes exactly
+        these points to boundary points via the "Input boundary points"
+        list in ww3_grid.inp (see write_ww3_input). A reentrant (cyclic-x)
+        edge has no physical boundary, so the east/west edges are only
+        flagged when the grid is not cyclic in x. Tripolar grids are
+        rejected outright (see assertion below): write_ww3_input's closure
+        logic has no 'TRPL' case, so the north/south edges are always
+        treated as physical boundaries here, which would be wrong for a
+        tripolar grid's pole fold.
+
+        Raises
+        ------
+        AssertionError
+            If the grid is tripolar.
+
+        Returns
+        -------
+        numpy.ndarray
+            (ny, nx) integer array of WW3 mapsta status codes.
+        """
+        assert not self._grid.is_tripolar(self._grid._supergrid), (
+            "write_ww3_input does not support tripolar grids: the pole fold "
+            "would be misidentified as an open boundary."
+        )
+
+        tmask = self.tmask.data  # (ny, nx), 1=ocean, 0=land
+        mapsta = tmask.astype(int).copy()
+
+        is_boundary = np.zeros_like(mapsta, dtype=bool)
+        is_boundary[0, :] = True
+        is_boundary[-1, :] = True
+        if not self._grid.supergrid.is_cyclic_x:
+            is_boundary[:, 0] = True
+            is_boundary[:, -1] = True
+
+        mapsta[is_boundary & (tmask == 1)] = 2
+        return mapsta
+
     def write_ww3_input(self, file_dir, grid_alias):
         """
         Write the text-based WW3 input files ww3_grid.inp, [grid_alias]_x.inp, [grid_alias]_y.inp,
@@ -2030,9 +2074,6 @@ class Topo:
 
         tlon = self._grid.tlon.data  # (ny, nx), degrees
         tlat = self._grid.tlat.data  # (ny, nx), degrees
-        # Define ocean cells from the land/sea mask so the depth and status files
-        # stay consistent even if the mask has been edited.
-        tmask = self.tmask.data  # (ny, nx), 1=ocean, 0=land
         depth_m = self.masked_depth.data
 
         x_file = f"{grid_alias}_x.inp"
@@ -2053,10 +2094,9 @@ class Topo:
         # ww3_tp2.5 (regtests/ww3_tp2.5/input/depth.361x361.IDLA1.dat).
         _write_rows(bottom_file, lambda j, i: f"{depth_m[j, i]:.8f}", sep=" ")
 
-        # --- map status file (1=ocean, 0=land) ---
-        # TODO: WW3 also supports mapsta codes 2 (active boundary), 3 (excluded),
-        # and negative values (ice). Extend when nested/boundary-forced runs are needed.
-        _write_rows(mapsta_file, lambda j, i: str(int(tmask[j, i])), sep=" ")
+        # --- map status file (0=land, 1=interior sea, 2=active boundary) ---
+        mapsta = self._compute_ww3_mapsta()
+        _write_rows(mapsta_file, lambda j, i: str(int(mapsta[j, i])), sep=" ")
 
         # --- Write ww3_grid.inp ---
         # Use IDLA=1 (bottom-to-top) and IDFM=1 (free format) to match the
@@ -2117,6 +2157,13 @@ class Topo:
             f.write(f"  22 1.0 0.0 1 1 '(....)' 'NAME' '{y_file}'\n")
             f.write(
                 f"  -0.1 {self._min_depth:.2f} 23 -1. 1 1 '(....)' 'NAME' '{bottom_file}'\n"
+            )
+            f.write(
+                "$ Input boundary points and excluded points -------------------------- $\n"
+                "$ The first line identifies where to get the map data, by unit number\n"
+                "$ IDLA and IDFM, format for formatted read, FROM and filename\n"
+                "$ if FROM = ’PART’, then segmented data is read from below, else\n"
+                "$ the data is read from file as with the other inputs (as INTEGER)\n"
             )
             f.write(f"  24 1 1 '(....)' 'NAME' '{mapsta_file}'\n")
             f.write(

--- a/tests/test_ww3_input.py
+++ b/tests/test_ww3_input.py
@@ -40,7 +40,14 @@ def test_write_ww3_input_array_contents(get_rect_topo_without_vc, tmp_path):
 
     # Flat ocean: positive depth everywhere, all cells wet.
     assert np.allclose(bottom, 1000.0)
-    assert (mapsta == 1).all()
+
+    # Non-cyclic grid: perimeter ocean cells are active boundary points (2),
+    # interior cells are ordinary sea points (1).
+    assert (mapsta[0, :] == 2).all()
+    assert (mapsta[-1, :] == 2).all()
+    assert (mapsta[:, 0] == 2).all()
+    assert (mapsta[:, -1] == 2).all()
+    assert (mapsta[1:-1, 1:-1] == 1).all()
 
 
 def test_write_ww3_input_grid_control_file(get_rect_topo_without_vc, tmp_path):
@@ -81,9 +88,34 @@ def test_write_ww3_input_masked_cells_are_land(get_rect_topo_without_vc, tmp_pat
         assert mapsta[j, i] == 0
         assert bottom[j, i] == 0.0
 
-    # mapsta is exactly the land/sea mask, and depth is zero wherever land.
-    assert np.array_equal(mapsta, topo.tmask.data)
+    # mapsta is 0 exactly where the land/sea mask is land (ocean cells are
+    # either interior sea points (1) or active boundary points (2)), and
+    # depth is zero wherever land.
+    assert np.array_equal(mapsta == 0, topo.tmask.data == 0)
     assert (bottom[mapsta == 0] == 0.0).all()
+
+
+def test_write_ww3_input_cyclic_grid_has_no_east_west_boundary(
+    get_simple_global_grid, tmp_path
+):
+    """A grid that is reentrant in x (e.g. a global band) has no physical
+    east/west boundary, so only the north/south edges should be flagged as
+    active boundary points (2) in mapsta; east/west edge cells remain
+    ordinary interior sea points (1)."""
+    from mom6_forge.topo import Topo
+
+    grid = get_simple_global_grid
+    topo = Topo(grid, min_depth=0, git=False)
+    topo.set_flat(1000)
+    alias = grid.name
+
+    topo.write_ww3_input(tmp_path, grid_alias=alias)
+    mapsta = np.loadtxt(tmp_path / f"{alias}_mapsta.inp")
+
+    assert (mapsta[0, :] == 2).all()
+    assert (mapsta[-1, :] == 2).all()
+    assert (mapsta[1:-1, 0] == 1).all()
+    assert (mapsta[1:-1, -1] == 1).all()
 
 
 def test_write_ww3_input_after_reconstruction_from_files(


### PR DESCRIPTION
Changes:

1. New function to do the mapsta, where if it's not cyclic the east/west boundaries become boundaries. North/South are always boundaries. 
2. Add a little commenting because the mapsta file should be in the input boundaries section of ww3_grid.inp not part of the other 3 files.