### PR TITLE
dateline wrapping by modulo

### DIFF
--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -112,15 +112,16 @@ class SupergridBase:
                 f"Longitude span is {span:.4f} degrees (> {max_span}); x looks "
                 "unwrapped/unbounded rather than a valid regional or global domain."
             )
-        # Every value must independently sit within [-360, 360]: with a span capped at
-        # 360 and the domain's own center within (-180, 180], no individual
-        # value can legitimately fall outside [-360, 360].
-        abs_bound = 360.0
-        if x.max() > abs_bound + tol or x.min() < -abs_bound - tol:
+        # Every value must independently sit within [-180, 540]: the fix targets
+        # a domain center within [0, 360) and, with span capped at 360, no
+        # individual value can legitimately fall outside 180 degrees either
+        # side of that -- i.e. [0 - 180, 360 + 180).
+        low_bound, high_bound = -180.0, 540.0
+        if x.max() > high_bound + tol or x.min() < low_bound - tol:
             raise ValueError(
-                f"Longitude values (range [{x.min():.4f}, {x.max():.4f}]) exceed "
-                f"+/-{abs_bound} degrees; x looks unwrapped/unnormalized rather "
-                "than a valid geographic longitude."
+                f"Longitude values (range [{x.min():.4f}, {x.max():.4f}]) fall "
+                f"outside [{low_bound}, {high_bound}]; x looks unwrapped/"
+                "unnormalized rather than a valid geographic longitude."
             )
         max_jump = _max_adjacent_diff(x)
         if max_jump > max_adjacent_jump:
@@ -234,11 +235,12 @@ class SupergridBase:
             if _max_adjacent_diff(x) > 180.0:
                 x = modulo_around_point(x, center_lon, 360)
             # Re-centering by a whole multiple of 360 is always safe (it can't
-            # introduce a new discontinuity, and shifting by exactly 0 -- the
-            # common case -- is a bit-identical no-op) so this always runs, to
-            # land the field as close to the conventional [-180, 180] range as
-            # the domain allows.
-            x = x - round(center_lon / 360) * 360
+            # introduce a new discontinuity, and shifting by exactly 0 is a
+            # bit-identical no-op) so this always runs, to land the field in
+            # the conventional [0, 360) range. Only a domain that itself
+            # straddles that seam (e.g. centered near the Prime Meridian)
+            # spills outside it, since no shift avoids that.
+            x = x - np.floor(center_lon / 360) * 360
 
         # dx, dy, area: use base class consistent calculation methods
         dx, dy = SupergridBase._calc_dx_dy(x, y, R=R, type=dx_dy_calc_type)

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -218,6 +218,31 @@ class SupergridBase:
         # Clamp to valid geographic range (floating-point overshoot from projection in some cases)
         y = np.clip(y, -90.0, 90.0)
 
+        # Longitude must be continuous before dx/dy/area/angle are computed by
+        # differencing adjacent x values: a raw dateline-wrap discontinuity (e.g.
+        # adjacent values of 179 and -179) corrupts those calculations at the seam.
+        # Skip entirely for domains that reach a pole: every longitude legitimately
+        # converges there, so no wrap can (or should) make them continuous.
+        if np.abs(y).max() < SupergridBase._POLE_ADJACENT_LAT:
+            center_lon = x[x.shape[0] // 2, x.shape[1] // 2]
+            # The per-element modulo is only needed (and only invoked) when the
+            # raw array actually contains a within-domain discontinuity (e.g. a
+            # raw PROJ transform whose +/-180 branch cut falls inside this
+            # domain) -- calling it unconditionally would round-trip every
+            # already-fine value through a floating-point modulo, introducing
+            # noise into arrays that never needed touching. Wrap around the
+            # grid's own center point rather than a fixed reference (e.g.
+            # Greenwich) so a domain straddling any seam is never split by the
+            # wrap itself.
+            if _max_adjacent_diff(x) > 180.0:
+                x = modulo_around_point(x, center_lon, 360)
+            # Re-centering by a whole multiple of 360 is always safe (it can't
+            # introduce a new discontinuity, and shifting by exactly 0 -- the
+            # common case -- is a bit-identical no-op) so this always runs, to
+            # land the field as close to the conventional [-180, 180] range as
+            # the domain allows.
+            x = x - round(center_lon / 360) * 360
+
         # dx, dy, area: use base class consistent calculation methods
         dx, dy = SupergridBase._calc_dx_dy(x, y, R=R, type=dx_dy_calc_type)
         area = SupergridBase._calc_area(x, y, R=R)
@@ -406,11 +431,6 @@ class UniformSphericalSupergrid(SupergridBase):
         grid_y = lat_min + jindp * len_y / ny_total  # latitude edges
         grid_x = lon_min + iindp * len_x / nx_total  # longitude edges
 
-        # ---------------------------------------------------------------------
-        # If there are longitudes larger than 360, shift to -180 -> 180 instead
-        # ---------------------------------------------------------------------
-        if grid_x.max() > 360:
-            grid_x -= 360
         # Form full 2D coordinate arrays for all cell corners
         x = np.tile(grid_x, (ny_total + 1, 1))
         y = np.tile(grid_y.reshape((ny_total + 1, 1)), (1, nx_total + 1))
@@ -466,11 +486,6 @@ class RectilinearCartesianSupergrid(SupergridBase):
         ), "provided array of longitudes must be uniformly spaced"
 
         lon, lat = np.meshgrid(lons, lats)
-        # ---------------------------------------------------------------------
-        # If there are longitudes larger than 360, shift to -180 -> 180 instead
-        # ---------------------------------------------------------------------
-        if lon.max() > 360:
-            lon -= 360
         return lon, lat
 
 
@@ -524,21 +539,9 @@ class ProjectedSupergrid(SupergridBase):
         y_sg = np.linspace(y_min, y_max, 2 * ny + 1)
         xx, yy = np.meshgrid(x_sg, y_sg)
 
-        center_lon = np.mean([x_min, x_max])
         transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+        lon, lat = transformer.transform(xx, yy)
 
-        transformer = Transformer.from_crs(
-            crs,
-            CRS.from_proj4(f"+proj=longlat +datum=WGS84 +pm={center_lon}"),
-            always_xy=True,
-        )
-        lon_rel, lat = transformer.transform(xx, yy)
-        lon = lon_rel + center_lon  # shift back to true (Greenwich-relative) longitude
-        # ---------------------------------------------------------------------
-        # If there are longitudes larger than 360, shift to -180 -> 180 instead
-        # ---------------------------------------------------------------------
-        if lon.max() > 360:
-            lon -= 360
         return cls._init_from_xy(lon, lat, "projected_crs", radius)
 
     @classmethod
@@ -594,18 +597,9 @@ class ProjectedSupergrid(SupergridBase):
         xx_rot = xx * np.cos(theta) + yy * np.sin(theta)
         yy_rot = -xx * np.sin(theta) + yy * np.cos(theta)
 
-        transformer = Transformer.from_crs(
-            crs,
-            CRS.from_proj4(f"+proj=longlat +datum=WGS84 +pm={center_lon}"),
-            always_xy=True,
-        )
-        lon_rel, lat = transformer.transform(xx_rot, yy_rot)
-        lon = lon_rel + center_lon  # shift back to true (Greenwich-relative) longitude
-        # ---------------------------------------------------------------------
-        # If there are longitudes larger than 360, shift to -180 -> 180 instead
-        # ---------------------------------------------------------------------
-        if lon.max() > 360:
-            lon -= 360
+        transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+        lon, lat = transformer.transform(xx_rot, yy_rot)
+
         return cls._init_from_xy(lon, lat, "projected_crs", radius)
 
 

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -112,10 +112,7 @@ class SupergridBase:
                 f"Longitude span is {span:.4f} degrees (> {max_span}); x looks "
                 "unwrapped/unbounded rather than a valid regional or global domain."
             )
-        # A gross unit bug upstream (e.g. treating projected metres as degrees)
-        # can produce values sitting at a huge absolute offset while still having
-        # a small *local* span, which the check above alone would miss. Every
-        # value must independently sit within [-360, 360]: with a span capped at
+        # Every value must independently sit within [-360, 360]: with a span capped at
         # 360 and the domain's own center within (-180, 180], no individual
         # value can legitimately fall outside [-360, 360].
         abs_bound = 360.0

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -341,6 +341,11 @@ class UniformSphericalSupergrid(SupergridBase):
         grid_y = lat_min + jindp * len_y / ny_total  # latitude edges
         grid_x = lon_min + iindp * len_x / nx_total  # longitude edges
 
+        # ---------------------------------------------------------------------
+        # If there are longitudes larger than 360, shift to -180 -> 180 instead
+        # ---------------------------------------------------------------------
+        if grid_x.max() > 360:
+            grid_x -= 360
         # Form full 2D coordinate arrays for all cell corners
         x = np.tile(grid_x, (ny_total + 1, 1))
         y = np.tile(grid_y.reshape((ny_total + 1, 1)), (1, nx_total + 1))
@@ -396,7 +401,11 @@ class RectilinearCartesianSupergrid(SupergridBase):
         ), "provided array of longitudes must be uniformly spaced"
 
         lon, lat = np.meshgrid(lons, lats)
-
+        # ---------------------------------------------------------------------
+        # If there are longitudes larger than 360, shift to -180 -> 180 instead
+        # ---------------------------------------------------------------------
+        if lon.max() > 360:
+            lon -= 360
         return lon, lat
 
 
@@ -450,9 +459,21 @@ class ProjectedSupergrid(SupergridBase):
         y_sg = np.linspace(y_min, y_max, 2 * ny + 1)
         xx, yy = np.meshgrid(x_sg, y_sg)
 
+        center_lon = np.mean([x_min, x_max])
         transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
-        lon, lat = transformer.transform(xx, yy)
 
+        transformer = Transformer.from_crs(
+            crs,
+            CRS.from_proj4(f"+proj=longlat +datum=WGS84 +pm={center_lon}"),
+            always_xy=True,
+        )
+        lon_rel, lat = transformer.transform(xx, yy)
+        lon = lon_rel + center_lon  # shift back to true (Greenwich-relative) longitude
+        # ---------------------------------------------------------------------
+        # If there are longitudes larger than 360, shift to -180 -> 180 instead
+        # ---------------------------------------------------------------------
+        if lon.max() > 360:
+            lon -= 360
         return cls._init_from_xy(lon, lat, "projected_crs", radius)
 
     @classmethod
@@ -508,9 +529,18 @@ class ProjectedSupergrid(SupergridBase):
         xx_rot = xx * np.cos(theta) + yy * np.sin(theta)
         yy_rot = -xx * np.sin(theta) + yy * np.cos(theta)
 
-        transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
-        lon, lat = transformer.transform(xx_rot, yy_rot)
-
+        transformer = Transformer.from_crs(
+            crs,
+            CRS.from_proj4(f"+proj=longlat +datum=WGS84 +pm={center_lon}"),
+            always_xy=True,
+        )
+        lon_rel, lat = transformer.transform(xx_rot, yy_rot)
+        lon = lon_rel + center_lon  # shift back to true (Greenwich-relative) longitude
+        # ---------------------------------------------------------------------
+        # If there are longitudes larger than 360, shift to -180 -> 180 instead
+        # ---------------------------------------------------------------------
+        if lon.max() > 360:
+            lon -= 360
         return cls._init_from_xy(lon, lat, "projected_crs", radius)
 
 

--- a/mom6_forge/_supergrid.py
+++ b/mom6_forge/_supergrid.py
@@ -21,6 +21,17 @@ from pyproj import CRS, Transformer
 from mom6_forge.utils import normalize_deg
 
 
+def _max_adjacent_diff(x):
+    """Largest absolute difference between horizontally or vertically adjacent
+    values of a 2D array. Used to detect a raw dateline-wrap discontinuity."""
+    max_diff = 0.0
+    if x.shape[1] > 1:
+        max_diff = max(max_diff, np.abs(np.diff(x, axis=1)).max())
+    if x.shape[0] > 1:
+        max_diff = max(max_diff, np.abs(np.diff(x, axis=0)).max())
+    return max_diff
+
+
 class SupergridBase:
     """Base class defining the MOM6-style supergrid interface."""
 
@@ -59,6 +70,8 @@ class SupergridBase:
         grid_type : str
             the type of grid being created
         """
+        if axis_units == "degrees":
+            self._validate_longitude_continuity(x, y)
         self.x = x
         self.y = y
         self.dx = dx
@@ -67,6 +80,58 @@ class SupergridBase:
         self.angle_dx = angle_dx
         self.axis_units = axis_units
         self.grid_type = grid_type
+
+    # Domains that reach this close to a pole legitimately surround every
+    # longitude (the pole is the one point where all meridians meet), so no
+    # wrap can make them continuous -- this is a real geometric singularity,
+    # not a wrap bug, and the validation below must leave such domains alone.
+    _POLE_ADJACENT_LAT = 89.9
+
+    @staticmethod
+    def _validate_longitude_continuity(x, y, max_span=360.0, max_adjacent_jump=180.0):
+        """Guard against the two dateline-wrapping failure modes this class must never produce.
+
+        1. A discontinuous jump between adjacent supergrid nodes (e.g. 179 next to
+           -179), which corrupts dx/dy/area/angle_dx since those are computed by
+           differencing adjacent x values.
+        2. Longitude values sitting at an implausible absolute offset (e.g. left in
+           the thousands of degrees by an upstream unit bug) or an unbounded span,
+           either of which indicates x was never wrapped/normalized at all.
+
+        A legitimate global, cyclic-in-x grid has span == 360 exactly (or a hair
+        over due to floating point), which is why the span check has a small
+        tolerance rather than being a strict `< 360`.
+        """
+        if np.abs(y).max() >= SupergridBase._POLE_ADJACENT_LAT:
+            return
+
+        tol = 1e-6
+        span = x.max() - x.min()
+        if span > max_span + tol:
+            raise ValueError(
+                f"Longitude span is {span:.4f} degrees (> {max_span}); x looks "
+                "unwrapped/unbounded rather than a valid regional or global domain."
+            )
+        # A gross unit bug upstream (e.g. treating projected metres as degrees)
+        # can produce values sitting at a huge absolute offset while still having
+        # a small *local* span, which the check above alone would miss. Every
+        # value must independently sit within [-360, 360]: with a span capped at
+        # 360 and the domain's own center within (-180, 180], no individual
+        # value can legitimately fall outside [-360, 360].
+        abs_bound = 360.0
+        if x.max() > abs_bound + tol or x.min() < -abs_bound - tol:
+            raise ValueError(
+                f"Longitude values (range [{x.min():.4f}, {x.max():.4f}]) exceed "
+                f"+/-{abs_bound} degrees; x looks unwrapped/unnormalized rather "
+                "than a valid geographic longitude."
+            )
+        max_jump = _max_adjacent_diff(x)
+        if max_jump > max_adjacent_jump:
+            raise ValueError(
+                f"Longitude array contains a jump of {max_jump:.4f} degrees between "
+                f"adjacent supergrid nodes (> {max_adjacent_jump}); this indicates an "
+                "un-wrapped dateline crossing."
+            )
 
     def __eq__(self, other):
         if not isinstance(other, SupergridBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -518,15 +518,18 @@ def get_PM_seam_grid():
 
 @pytest.fixture(scope="module")
 def get_dateline_seam_grid():
-    """2×2 grid straddling the dateline / antimeridian seam (-1-1°E, -1-1°N).
+    """2×2 grid straddling the dateline / antimeridian seam (179-181°E, -1-1°N).
 
     Use to verify that longitude arithmetic handles the ±180° wraparound
     correctly.  Pair with get_PM_seam_grid to distinguish dateline-seam bugs
     from Prime-Meridian-seam bugs.
+
+    Note: xstart=-1 previously put this at 0°E (the Prime Meridian, same seam
+    as get_PM_seam_grid), not the antimeridian its name/docstring claimed.
     """
     grid = Grid(
         resolution=1,
-        xstart=-1,
+        xstart=179,
         lenx=2,
         ystart=-1,
         leny=2,

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -356,4 +356,5 @@ def test_grid_from_center():
     mid_lat = grid.tlat.values[grid.ny // 2, grid.nx // 2]
     mid_lon = grid.tlon.values[grid.ny // 2, grid.nx // 2]
     assert abs(mid_lat - 40.0) < 1.0
-    assert abs(mid_lon - (-70.0)) < 1.0
+    # Output longitude is normalized to [0, 360), so -70 comes back as 290.
+    assert abs(mid_lon - 290.0) < 1.0

--- a/tests/test_longitude_wrapping.py
+++ b/tests/test_longitude_wrapping.py
@@ -1,41 +1,13 @@
-"""Exhaustive check that every supergrid builder produces continuous, bounded
-longitude, regardless of where the domain sits relative to the two seams that
-360-degree periodicity creates: the Prime Meridian (0/360 wrap) and the
-antimeridian (+/-180 wrap).
+"""Every supergrid builder must produce continuous, bounded longitude,
+regardless of where the domain sits relative to the two 360-degree seams:
+the Prime Meridian (0/360 wrap) and the antimeridian (+/-180 wrap).
 
-Each of the 4 grid-building entry points (UniformSphericalSupergrid,
-RectilinearCartesianSupergrid, ProjectedSupergrid.from_crs,
-ProjectedSupergrid.from_center) is exercised in 3 configurations:
-
-- regular:        domain far from both seams (sanity check / no-op case)
-- pm_seam:        domain straddling the Prime Meridian
-- dateline_seam:  domain straddling the antimeridian
-
-giving a 4x3 = 12-grid matrix, all checked by one parametrized test against
-the two invariants SupergridBase.__init__ enforces:
-
-1. No discontinuous jump between adjacent supergrid nodes (would corrupt
-   dx/dy/area/angle_dx, which are computed by differencing adjacent x values).
-2. No unbounded longitude span, and no value sitting at an implausible
-   absolute offset (either is a sign x was never wrapped/normalized at all --
-   the latter guards against e.g. an upstream unit bug that leaves a locally
-   well-behaved but globally nonsensical value like ~500,000 degrees).
-
-Domains that reach within 0.1 degrees of a pole are exempt from both checks:
-every longitude legitimately converges there, so a jump is an unavoidable
-geometric singularity, not a wrap bug (see test_pole_adjacent_domain_is_exempt).
-
-For the extent-based grids (Uniform/Rectilinear), the Prime Meridian case
-uses the >360 overflow representation (lon_min=350) since that is the exact
-numeric form that broke prior to the fix; the antimeridian case uses a
-plain 170-190 range, which was never discontinuous for these linspace-built
-grids but should still land inside the invariants.
-
-For the projected grids, the antimeridian case is the one that produces a
-genuine raw discontinuity (pyproj's inverse transform has its branch cut at
-+/-180, not at 0/360), so it is the interesting case for rule 1. The
-Prime-Meridian case for these two mainly exercises rule 2's re-centering step
-at a boundary-adjacent value.
+GRID_MATRIX exercises all 4 builders x 3 seam positions (12 grids) against
+the two invariants SupergridBase.__init__ enforces: no discontinuous jump
+between adjacent nodes, and no unbounded/implausible longitude range.
+Domains within 0.1 degrees of a pole are exempt from both -- see
+test_pole_adjacent_domain_is_exempt_from_continuity_check -- since every
+longitude converges there; a jump is a geometric singularity, not a wrap bug.
 """
 
 import numpy as np
@@ -44,12 +16,12 @@ import pytest
 from mom6_forge._supergrid import (
     ProjectedSupergrid,
     RectilinearCartesianSupergrid,
+    SupergridBase,
     UniformSphericalSupergrid,
+    _max_adjacent_diff,
 )
 
-EXTENT_LEN = 20.0  # degrees
-EXTENT_LAT_MIN = -5.0
-EXTENT_LEN_Y = 10.0
+EXTENT_LEN, EXTENT_LAT_MIN, EXTENT_LEN_Y = 20.0, -5.0, 10.0  # degrees
 
 
 def _uniform_spherical(lon_min):
@@ -90,6 +62,9 @@ def _projected_from_center(center_lon):
     )
 
 
+# lon_min/center_lon per seam: regular = away from either seam, pm_seam =
+# straddles 0/360 (extent grids use the >360 overflow form), dateline_seam =
+# straddles +/-180.
 GRID_MATRIX = [
     ("uniform_spherical", "regular", lambda: _uniform_spherical(15.0)),
     ("uniform_spherical", "pm_seam", lambda: _uniform_spherical(350.0)),
@@ -110,133 +85,80 @@ GRID_MATRIX = [
 ]
 
 
-def _max_adjacent_jump(x):
-    max_jump = 0.0
-    if x.shape[1] > 1:
-        max_jump = max(max_jump, np.abs(np.diff(x, axis=1)).max())
-    if x.shape[0] > 1:
-        max_jump = max(max_jump, np.abs(np.diff(x, axis=0)).max())
-    return max_jump
-
-
 @pytest.mark.parametrize(
     ("grid_type", "seam", "builder"),
     GRID_MATRIX,
     ids=[f"{grid_type}-{seam}" for grid_type, seam, _ in GRID_MATRIX],
 )
 def test_longitude_is_continuous_and_bounded(grid_type, seam, builder):
-    grid = builder()
-    x = grid.x
+    x = builder().x
+    print(f"{grid_type}/{seam}: x at seam row = {np.round(x[x.shape[0] // 2], 2)}")
 
-    max_jump = _max_adjacent_jump(x)
+    max_jump = _max_adjacent_diff(x)
     assert max_jump < 180.0, (
-        f"{grid_type}/{seam}: adjacent-node longitude jump of {max_jump:.2f} "
-        "degrees indicates an un-wrapped seam discontinuity"
+        f"{grid_type}/{seam}: adjacent-node jump of {max_jump:.2f} degrees "
+        "indicates an un-wrapped seam discontinuity"
     )
 
     span = x.max() - x.min()
-    assert span < 360.0 + 1e-6, (
-        f"{grid_type}/{seam}: longitude span of {span:.2f} degrees looks "
-        "unbounded/unwrapped"
-    )
-
-
-def test_pole_adjacent_domain_is_exempt_from_continuity_check():
-    """A projected domain centered on the pole (e.g. a full Arctic cap) legitimately
-    contains every longitude -- there is no wrap that makes this continuous, since
-    the pole is the one point where all meridians meet. This must build without
-    raising, unlike a genuine un-wrapped dateline bug at lower latitudes."""
-    grid = ProjectedSupergrid.from_crs(
-        "EPSG:3995", -500_000, 500_000, -500_000, 500_000, resolution_m=50_000
-    )
-    assert np.abs(grid.y).max() >= 89.9
     assert (
-        _max_adjacent_jump(grid.x) > 180.0
-    )  # confirms this is the case we're exempting
+        span < 360.0 + 1e-6
+    ), f"{grid_type}/{seam}: longitude span of {span:.2f} degrees looks unbounded"
 
 
 def test_global_cyclic_grid_still_spans_exactly_360():
-    """Regression guard: a legitimate global grid (span == 360, the one case the
-    invariant checks must not reject) must still build and keep its cyclic
-    0->360 span, not get collapsed to a smaller wrapped range."""
-    grid = UniformSphericalSupergrid.from_extents(
+    """A legitimate global grid (span == 360) must build and keep its cyclic
+    0->360 span, not get rejected or collapsed to a smaller wrapped range."""
+    x = UniformSphericalSupergrid.from_extents(
         lon_min=0.0, len_x=360.0, lat_min=-5.0, len_y=10.0, nx=180, ny=5
-    )
-    assert np.isclose(grid.x.max() - grid.x.min(), 360.0)
-    assert _max_adjacent_jump(grid.x) < 180.0
+    ).x
+    assert np.isclose(x.max() - x.min(), 360.0)
+    assert _max_adjacent_diff(x) < 180.0
 
 
+# dx/dy/area/angle_dx are never inspected by the __init__ guard, so a single
+# zeros array of x's shape stands in for all four below.
 @pytest.mark.parametrize(
-    ("x", "expect_error", "match"),
+    ("x", "match"),
     [
+        pytest.param([[178.0, 179.0, -179.0, -178.0]], "jump", id="raw-discontinuity"),
+        pytest.param([[0.0, 200.0, 400.0, 600.0]], "span", id="unbounded-span"),
         pytest.param(
-            np.array([[178.0, 179.0, -179.0, -178.0]]),
-            True,
-            "jump",
-            id="raw-discontinuity",
-        ),
-        pytest.param(
-            np.array([[0.0, 200.0, 400.0, 600.0]]),
-            True,
-            "span",
-            id="unbounded-span",
-        ),
-        pytest.param(
-            np.array([[100_000.0, 100_001.0, 100_002.0]]),
-            True,
+            [[100_000.0, 100_001.0, 100_002.0]],
             "exceed",
             id="huge-absolute-offset-small-local-span",
         ),
         pytest.param(
-            np.array([[178.0, 179.0, 180.0, 181.0]]),
-            False,
-            None,
-            id="continuous-but-unconventional-range",
+            [[178.0, 179.0, 180.0, 181.0]], None, id="continuous-but-unconventional"
         ),
         pytest.param(
-            np.array([[0.0, 90.0, 180.0, 270.0, 360.0]]),
-            False,
-            None,
-            id="exact-360-span-boundary",
+            [[0.0, 90.0, 180.0, 270.0, 360.0]], None, id="exact-360-span-boundary"
         ),
     ],
 )
-def test_init_validates_longitude_directly(x, expect_error, match):
-    """Unit-test the SupergridBase.__init__ guard itself (independent of any
-    builder), including the from_ds load path which bypasses _init_from_xy's
-    wrap and so relies on this check as the only safety net."""
-    y = np.zeros_like(x)
-    dx = np.diff(x, axis=1) if x.shape[1] > 1 else np.zeros((x.shape[0], 0))
-    dy = np.zeros((0, x.shape[1]))
-    area = np.zeros((max(x.shape[0] - 1, 0), max(x.shape[1] - 1, 0)))
-    angle_dx = np.zeros_like(x)
-
-    from mom6_forge._supergrid import SupergridBase
-
-    if expect_error:
+def test_init_validates_longitude_directly(x, match):
+    """Unit-test the __init__ guard itself, independent of any builder -- this
+    is also the only safety net for the from_ds load path, which bypasses
+    _init_from_xy's wrap entirely."""
+    x = np.array(x)
+    zeros = np.zeros_like(x)
+    if match:
         with pytest.raises(ValueError, match=match):
-            SupergridBase(x, y, dx, dy, area, angle_dx, "degrees", grid_type="test")
+            SupergridBase(x, zeros, zeros, zeros, zeros, zeros, "degrees", "test")
     else:
-        grid = SupergridBase(x, y, dx, dy, area, angle_dx, "degrees", grid_type="test")
+        grid = SupergridBase(x, zeros, zeros, zeros, zeros, zeros, "degrees", "test")
         assert grid.x is x
 
 
 def test_init_validation_exempts_pole_adjacent_latitude():
     """The same raw discontinuity that raises at low latitude must be waved
-    through when y indicates the domain sits at a pole -- directly exercising
-    the __init__ guard's exemption, independent of any projection machinery."""
-    from mom6_forge._supergrid import SupergridBase
-
+    through when y indicates the domain sits at a pole."""
     x = np.array([[178.0, 179.0, -179.0, -178.0]])
-    dx = np.diff(x, axis=1)
-    dy = np.zeros((0, x.shape[1]))
-    area = np.zeros((0, x.shape[1] - 1))
-    angle_dx = np.zeros_like(x)
+    zeros = np.zeros_like(x)
 
-    y_equator = np.zeros_like(x)
     with pytest.raises(ValueError, match="jump"):
-        SupergridBase(x, y_equator, dx, dy, area, angle_dx, "degrees", grid_type="test")
+        SupergridBase(x, zeros, zeros, zeros, zeros, zeros, "degrees", "test")
 
     y_pole = np.full_like(x, 89.95)
-    grid = SupergridBase(x, y_pole, dx, dy, area, angle_dx, "degrees", grid_type="test")
+    grid = SupergridBase(x, y_pole, zeros, zeros, zeros, zeros, "degrees", "test")
     assert grid.x is x

--- a/tests/test_longitude_wrapping.py
+++ b/tests/test_longitude_wrapping.py
@@ -1,0 +1,242 @@
+"""Exhaustive check that every supergrid builder produces continuous, bounded
+longitude, regardless of where the domain sits relative to the two seams that
+360-degree periodicity creates: the Prime Meridian (0/360 wrap) and the
+antimeridian (+/-180 wrap).
+
+Each of the 4 grid-building entry points (UniformSphericalSupergrid,
+RectilinearCartesianSupergrid, ProjectedSupergrid.from_crs,
+ProjectedSupergrid.from_center) is exercised in 3 configurations:
+
+- regular:        domain far from both seams (sanity check / no-op case)
+- pm_seam:        domain straddling the Prime Meridian
+- dateline_seam:  domain straddling the antimeridian
+
+giving a 4x3 = 12-grid matrix, all checked by one parametrized test against
+the two invariants SupergridBase.__init__ enforces:
+
+1. No discontinuous jump between adjacent supergrid nodes (would corrupt
+   dx/dy/area/angle_dx, which are computed by differencing adjacent x values).
+2. No unbounded longitude span, and no value sitting at an implausible
+   absolute offset (either is a sign x was never wrapped/normalized at all --
+   the latter guards against e.g. an upstream unit bug that leaves a locally
+   well-behaved but globally nonsensical value like ~500,000 degrees).
+
+Domains that reach within 0.1 degrees of a pole are exempt from both checks:
+every longitude legitimately converges there, so a jump is an unavoidable
+geometric singularity, not a wrap bug (see test_pole_adjacent_domain_is_exempt).
+
+For the extent-based grids (Uniform/Rectilinear), the Prime Meridian case
+uses the >360 overflow representation (lon_min=350) since that is the exact
+numeric form that broke prior to the fix; the antimeridian case uses a
+plain 170-190 range, which was never discontinuous for these linspace-built
+grids but should still land inside the invariants.
+
+For the projected grids, the antimeridian case is the one that produces a
+genuine raw discontinuity (pyproj's inverse transform has its branch cut at
++/-180, not at 0/360), so it is the interesting case for rule 1. The
+Prime-Meridian case for these two mainly exercises rule 2's re-centering step
+at a boundary-adjacent value.
+"""
+
+import numpy as np
+import pytest
+
+from mom6_forge._supergrid import (
+    ProjectedSupergrid,
+    RectilinearCartesianSupergrid,
+    UniformSphericalSupergrid,
+)
+
+EXTENT_LEN = 20.0  # degrees
+EXTENT_LAT_MIN = -5.0
+EXTENT_LEN_Y = 10.0
+
+
+def _uniform_spherical(lon_min):
+    return UniformSphericalSupergrid.from_extents(
+        lon_min, EXTENT_LEN, EXTENT_LAT_MIN, EXTENT_LEN_Y, nx=10, ny=5
+    )
+
+
+def _rectilinear_cartesian(lon_min):
+    return RectilinearCartesianSupergrid.from_extents(
+        lon_min, EXTENT_LEN, EXTENT_LAT_MIN, EXTENT_LEN_Y, resolution=2.0
+    )
+
+
+# EPSG:3995 (Arctic polar stereographic) directions, found by sweeping angle
+# around the pole: +x -> lon=90, +y -> lon=180 (antimeridian), -y -> lon=0 (PM).
+_CRS_OFFSETS = {
+    "regular": dict(x=(3_200_000, 3_800_000), y=(-300_000, 300_000)),
+    "pm_seam": dict(x=(-300_000, 300_000), y=(-3_800_000, -3_200_000)),
+    "dateline_seam": dict(x=(-300_000, 300_000), y=(3_200_000, 3_800_000)),
+}
+
+
+def _projected_from_crs(seam):
+    off = _CRS_OFFSETS[seam]
+    return ProjectedSupergrid.from_crs(
+        "EPSG:3995", *off["x"], *off["y"], resolution_m=100_000
+    )
+
+
+def _projected_from_center(center_lon):
+    return ProjectedSupergrid.from_center(
+        center_lat=40.0,
+        center_lon=center_lon,
+        width_m=400_000,
+        height_m=400_000,
+        resolution_m=100_000,
+    )
+
+
+GRID_MATRIX = [
+    ("uniform_spherical", "regular", lambda: _uniform_spherical(15.0)),
+    ("uniform_spherical", "pm_seam", lambda: _uniform_spherical(350.0)),
+    ("uniform_spherical", "dateline_seam", lambda: _uniform_spherical(170.0)),
+    ("rectilinear_cartesian", "regular", lambda: _rectilinear_cartesian(15.0)),
+    ("rectilinear_cartesian", "pm_seam", lambda: _rectilinear_cartesian(350.0)),
+    ("rectilinear_cartesian", "dateline_seam", lambda: _rectilinear_cartesian(170.0)),
+    ("projected_from_crs", "regular", lambda: _projected_from_crs("regular")),
+    ("projected_from_crs", "pm_seam", lambda: _projected_from_crs("pm_seam")),
+    (
+        "projected_from_crs",
+        "dateline_seam",
+        lambda: _projected_from_crs("dateline_seam"),
+    ),
+    ("projected_from_center", "regular", lambda: _projected_from_center(-70.0)),
+    ("projected_from_center", "pm_seam", lambda: _projected_from_center(0.5)),
+    ("projected_from_center", "dateline_seam", lambda: _projected_from_center(180.0)),
+]
+
+
+def _max_adjacent_jump(x):
+    max_jump = 0.0
+    if x.shape[1] > 1:
+        max_jump = max(max_jump, np.abs(np.diff(x, axis=1)).max())
+    if x.shape[0] > 1:
+        max_jump = max(max_jump, np.abs(np.diff(x, axis=0)).max())
+    return max_jump
+
+
+@pytest.mark.parametrize(
+    ("grid_type", "seam", "builder"),
+    GRID_MATRIX,
+    ids=[f"{grid_type}-{seam}" for grid_type, seam, _ in GRID_MATRIX],
+)
+def test_longitude_is_continuous_and_bounded(grid_type, seam, builder):
+    grid = builder()
+    x = grid.x
+
+    max_jump = _max_adjacent_jump(x)
+    assert max_jump < 180.0, (
+        f"{grid_type}/{seam}: adjacent-node longitude jump of {max_jump:.2f} "
+        "degrees indicates an un-wrapped seam discontinuity"
+    )
+
+    span = x.max() - x.min()
+    assert span < 360.0 + 1e-6, (
+        f"{grid_type}/{seam}: longitude span of {span:.2f} degrees looks "
+        "unbounded/unwrapped"
+    )
+
+
+def test_pole_adjacent_domain_is_exempt_from_continuity_check():
+    """A projected domain centered on the pole (e.g. a full Arctic cap) legitimately
+    contains every longitude -- there is no wrap that makes this continuous, since
+    the pole is the one point where all meridians meet. This must build without
+    raising, unlike a genuine un-wrapped dateline bug at lower latitudes."""
+    grid = ProjectedSupergrid.from_crs(
+        "EPSG:3995", -500_000, 500_000, -500_000, 500_000, resolution_m=50_000
+    )
+    assert np.abs(grid.y).max() >= 89.9
+    assert (
+        _max_adjacent_jump(grid.x) > 180.0
+    )  # confirms this is the case we're exempting
+
+
+def test_global_cyclic_grid_still_spans_exactly_360():
+    """Regression guard: a legitimate global grid (span == 360, the one case the
+    invariant checks must not reject) must still build and keep its cyclic
+    0->360 span, not get collapsed to a smaller wrapped range."""
+    grid = UniformSphericalSupergrid.from_extents(
+        lon_min=0.0, len_x=360.0, lat_min=-5.0, len_y=10.0, nx=180, ny=5
+    )
+    assert np.isclose(grid.x.max() - grid.x.min(), 360.0)
+    assert _max_adjacent_jump(grid.x) < 180.0
+
+
+@pytest.mark.parametrize(
+    ("x", "expect_error", "match"),
+    [
+        pytest.param(
+            np.array([[178.0, 179.0, -179.0, -178.0]]),
+            True,
+            "jump",
+            id="raw-discontinuity",
+        ),
+        pytest.param(
+            np.array([[0.0, 200.0, 400.0, 600.0]]),
+            True,
+            "span",
+            id="unbounded-span",
+        ),
+        pytest.param(
+            np.array([[100_000.0, 100_001.0, 100_002.0]]),
+            True,
+            "exceed",
+            id="huge-absolute-offset-small-local-span",
+        ),
+        pytest.param(
+            np.array([[178.0, 179.0, 180.0, 181.0]]),
+            False,
+            None,
+            id="continuous-but-unconventional-range",
+        ),
+        pytest.param(
+            np.array([[0.0, 90.0, 180.0, 270.0, 360.0]]),
+            False,
+            None,
+            id="exact-360-span-boundary",
+        ),
+    ],
+)
+def test_init_validates_longitude_directly(x, expect_error, match):
+    """Unit-test the SupergridBase.__init__ guard itself (independent of any
+    builder), including the from_ds load path which bypasses _init_from_xy's
+    wrap and so relies on this check as the only safety net."""
+    y = np.zeros_like(x)
+    dx = np.diff(x, axis=1) if x.shape[1] > 1 else np.zeros((x.shape[0], 0))
+    dy = np.zeros((0, x.shape[1]))
+    area = np.zeros((max(x.shape[0] - 1, 0), max(x.shape[1] - 1, 0)))
+    angle_dx = np.zeros_like(x)
+
+    from mom6_forge._supergrid import SupergridBase
+
+    if expect_error:
+        with pytest.raises(ValueError, match=match):
+            SupergridBase(x, y, dx, dy, area, angle_dx, "degrees", grid_type="test")
+    else:
+        grid = SupergridBase(x, y, dx, dy, area, angle_dx, "degrees", grid_type="test")
+        assert grid.x is x
+
+
+def test_init_validation_exempts_pole_adjacent_latitude():
+    """The same raw discontinuity that raises at low latitude must be waved
+    through when y indicates the domain sits at a pole -- directly exercising
+    the __init__ guard's exemption, independent of any projection machinery."""
+    from mom6_forge._supergrid import SupergridBase
+
+    x = np.array([[178.0, 179.0, -179.0, -178.0]])
+    dx = np.diff(x, axis=1)
+    dy = np.zeros((0, x.shape[1]))
+    area = np.zeros((0, x.shape[1] - 1))
+    angle_dx = np.zeros_like(x)
+
+    y_equator = np.zeros_like(x)
+    with pytest.raises(ValueError, match="jump"):
+        SupergridBase(x, y_equator, dx, dy, area, angle_dx, "degrees", grid_type="test")
+
+    y_pole = np.full_like(x, 89.95)
+    grid = SupergridBase(x, y_pole, dx, dy, area, angle_dx, "degrees", grid_type="test")
+    assert grid.x is x

--- a/tests/test_longitude_wrapping.py
+++ b/tests/test_longitude_wrapping.py
@@ -125,7 +125,7 @@ def test_global_cyclic_grid_still_spans_exactly_360():
         pytest.param([[0.0, 200.0, 400.0, 600.0]], "span", id="unbounded-span"),
         pytest.param(
             [[100_000.0, 100_001.0, 100_002.0]],
-            "exceed",
+            "outside",
             id="huge-absolute-offset-small-local-span",
         ),
         pytest.param(

--- a/tests/test_longitude_wrapping.py
+++ b/tests/test_longitude_wrapping.py
@@ -6,8 +6,8 @@ GRID_MATRIX exercises all 4 builders x 3 seam positions (12 grids) against
 the two invariants SupergridBase.__init__ enforces: no discontinuous jump
 between adjacent nodes, and no unbounded/implausible longitude range.
 Domains within 0.1 degrees of a pole are exempt from both -- see
-test_pole_adjacent_domain_is_exempt_from_continuity_check -- since every
-longitude converges there; a jump is a geometric singularity, not a wrap bug.
+test_init_validation_exempts_pole_adjacent_latitude -- since every longitude
+converges there; a jump is a geometric singularity, not a wrap bug.
 """
 
 import numpy as np

--- a/tests/test_supergrid.py
+++ b/tests/test_supergrid.py
@@ -76,7 +76,8 @@ def test_projected_supergrid_from_center():
     centre_lat = sg.y[sg.y.shape[0] // 2, sg.y.shape[1] // 2]
     centre_lon = sg.x[sg.x.shape[0] // 2, sg.x.shape[1] // 2]
     assert abs(centre_lat - center_lat) < 1.0
-    assert abs(centre_lon - center_lon) < 1.0
+    # Output longitude is normalized to [0, 360), so -70 comes back as 290.
+    assert abs(centre_lon - (center_lon % 360)) < 1.0
 
 
 def test_projected_supergrid_from_center_rotated():
@@ -99,7 +100,8 @@ def test_projected_supergrid_from_center_rotated():
     cy = sg_45.y[sg_45.y.shape[0] // 2, sg_45.y.shape[1] // 2]
     cx = sg_45.x[sg_45.x.shape[0] // 2, sg_45.x.shape[1] // 2]
     assert abs(cy - center_lat) < 1.0
-    assert abs(cx - center_lon) < 1.0
+    # Output longitude is normalized to [0, 360), so -70 comes back as 290.
+    assert abs(cx - (center_lon % 360)) < 1.0
     assert ((sg_45.angle_dx + np.deg2rad(45.0)) < 0.1).all()
 
 


### PR DESCRIPTION
There is an issue with seams me and @ashjbarnes were trying to fix: 


We can't have a major jump in longitude across seams, it messes with the metric calculations. So we use degrees east at the antimeridian, and negative degrees (-10 ->10) at the prime meridian. The way that's done is with the module_around_point function.