### PR TITLE
Make gen_rof_maps() tractable at production ROF mesh scale

### DIFF
--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -219,6 +219,74 @@ _DEFLATE_LEVEL = 4
 _DEFLATE_MIN_SIZE = 4096
 
 
+# ESMF_FactorRead.F90 splits the weight list across PETs with
+
+#     esplit    = floor(real(nElements) / real(petCount))
+#     remainder = nElements - esplit*petCount
+#     lb        = localPet*esplit + remainder + 1
+#
+# where `real` is the default REAL, i.e. float32. Above 2**24 that cannot hold
+# n_s exactly; when it rounds *up*, esplit*petCount overshoots n_s, `remainder`
+# goes negative, and PET 0 hands netCDF a negative start index. The run dies in
+# datainitialize with "ESMF_FactorRead netCDF Status Return Error" (checked
+# against ESMF v8.9.1). It has nothing to do with the file's format - classic,
+# cdf5 and netCDF4 all fail the same way.
+#
+# n_s <= 2**24 is provably safe: the quotient can only round across an integer
+# boundary when |n_s/petCount - m| < ulp/2 for some integer m, and since
+# |n_s - m*petCount| >= 1 that needs n_s > 2**24. Past that, rounding n_s up to a
+# multiple of 1024 keeps it exactly representable in float32 (for n_s < 2**33)
+# and makes n_s divisible by every power-of-two petCount up to 1024, which drives
+# `remainder` to exactly 0.
+#
+# This does NOT cover every petCount - a petCount that does not divide n_s can
+# still round badly (for n_s = 400,669,696, 87 of the first 4096 counts do,
+# including 24 and 30). Power-of-two mediator layouts, which is what CESM uses,
+# are safe. Remove all of this once ESMF does the split in integer arithmetic.
+_ESMF_FACTORREAD_EXACT_MAX = 2**24
+_N_S_ALIGNMENT = 1024
+_N_S_ALIGNMENT_MAX = 2**33
+
+
+def _pad_weights_for_esmf(S, row, col):
+    """Pad the weight list so ESMF_FactorRead's float32 PET split stays valid.
+
+    Appends zero-weight entries that reuse the first real (row, col) pair, so
+    the sparse mat-vec is unchanged and the route handle's set of source and
+    destination cells is exactly what it already was. A pair the map does not
+    otherwise use would pull an extra source cell into the communication
+    pattern, and 0 * NaN would then poison its destination cell.
+
+    ESMF sums duplicate index pairs - verified against esmpy 8.9.1, where an
+    unpadded file, one padded with identical pairs and one padded with distinct
+    pairs all produced bit-identical output.
+    """
+    n_s = S.sizes["n_s"]
+    if n_s <= _ESMF_FACTORREAD_EXACT_MAX or n_s % _N_S_ALIGNMENT == 0:
+        return S, row, col
+    if n_s >= _N_S_ALIGNMENT_MAX:
+        raise ValueError(
+            f"n_s = {n_s:,} is at or above 2**33, where an alignment of "
+            f"{_N_S_ALIGNMENT} no longer guarantees an exact float32 value; "
+            "ESMF_FactorRead's PET split cannot be made safe by padding here."
+        )
+    n_pad = -(-n_s // _N_S_ALIGNMENT) * _N_S_ALIGNMENT - n_s
+    print(
+        f"  padding n_s {n_s:,} -> {n_s + n_pad:,} (+{n_pad} zero-weight entries) "
+        "to keep ESMF_FactorRead's float32 PET split valid"
+    )
+    pad = lambda da, fill: xr.DataArray(
+        np.concatenate([da.data, np.full(n_pad, fill, dtype=da.dtype)]),
+        dims=["n_s"],
+        attrs=da.attrs,
+    )
+    return (
+        pad(S, 0),
+        pad(row, row.data[0]),
+        pad(col, col.data[0]),
+    )
+
+
 def _write_map_netcdf(ds, filename, single_precision=False):
     """Write a mapping-file dataset out as compressed netCDF4.
 
@@ -564,9 +632,9 @@ def write_mapping_file(
 
     # Drop NaN values from S, col, and row
     non_nan_indices = np.where(~np.isnan(S))[0]
-    ds_vars["S"] = S[non_nan_indices]
-    ds_vars["row"] = row[non_nan_indices]
-    ds_vars["col"] = col[non_nan_indices]
+    ds_vars["S"], ds_vars["row"], ds_vars["col"] = _pad_weights_for_esmf(
+        S[non_nan_indices], row[non_nan_indices], col[non_nan_indices]
+    )
 
     # Create the dataset and write to a netCDF file
     # ------------------------------------------------

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import xarray as xr
 import numpy as np
+import netCDF4
 import datetime
 from time import time
 from pathlib import Path
@@ -197,6 +198,161 @@ def _construct_vertex_coords(mesh):
     return xv_data, yv_data
 
 
+# Only "S", "row", and "col" - one-dimensional over the "n_s" dimension - are
+# actually read back when a mapping file is turned into a route handle: CMEPS
+# calls ESMF_FieldSMMStore(fldsrc, flddst, mapfile, ...) (med_map_mod.F90),
+# which dispatches to ESMF_FieldSMMStoreFromFile -> ESMF_FactorRead, and
+# ESMF_FactorRead.F90 states plainly that "Only 'row', 'col', and 'S' variables
+# are required". Everything else in the CESM/SCRIP mapping-file layout is
+# descriptive, and on large grids it dwarfs the weights themselves: for a global
+# GLOFAS source mesh (n_a = 21,600,000) the per-source-cell geometry alone is
+# over 2 GB, all of it recoverable from the source mesh file it was derived from.
+#
+# src_grid_dims/dst_grid_dims are kept even in a minimal file because they are
+# two integers each and record the (nx, ny) shape that the flat n_a/n_b indices
+# in col/row refer to - the one piece of context the weights can't carry.
+MINIMAL_MAP_VARIABLES = ("src_grid_dims", "dst_grid_dims", "S", "col", "row")
+
+# Deflate settings for the NETCDF4 record-keeping companion. Level 4 is the
+# knee of the curve on this data - most of what level 9 gets, at a fraction of
+# the write cost - and there is no point chunking arrays smaller than a chunk.
+_DEFLATE_LEVEL = 4
+_DEFLATE_MIN_SIZE = 4096
+
+
+def get_full_map_filepath(map_filepath):
+    """Get the companion "full" (all-variables) path for a given mapping file path.
+
+    Parameters
+    ----------
+    map_filepath : str or Path
+        Path to the primary (minimal) mapping file.
+
+    Returns
+    -------
+    Path
+        Same directory and suffix, with "_full" appended to the stem.
+    """
+    map_filepath = Path(map_filepath)
+    return map_filepath.with_name(f"{map_filepath.stem}_full{map_filepath.suffix}")
+
+
+def _require_nccopy():
+    """nccopy is how anything classic-format gets written here - see
+    `_write_map_netcdf`'s note on the classic writer's I/O behaviour."""
+    if shutil.which("nccopy") is None:
+        raise RuntimeError(
+            "write_mapping_file() requires the 'nccopy' command-line tool "
+            "(part of the netCDF-C distribution) on PATH to write the "
+            "NETCDF3_64BIT mapping file CESM's readers require."
+        )
+
+
+def _write_map_netcdf(ds, filename, single_precision=False, classic=True):
+    """Write a mapping-file dataset out to netCDF.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The mapping-file dataset to write.
+    filename : str or Path
+        Path to the output mapping file.
+    single_precision : bool, optional
+        If True, write every 64-bit float variable as 32-bit, halving the size of
+        the dominant variables. netCDF converts on read, and ESMF_FactorRead
+        reads S into a real(ESMF_KIND_R8) buffer regardless of the on-disk type,
+        so a single-precision file is still a valid ESMF weight file.
+    classic : bool, optional
+        If True (the default), write NETCDF3_64BIT, which is what CESM's
+        mapping-file readers require. If False, write NETCDF4 with deflate
+        compression - appropriate for a file that is never handed to CESM, and
+        the only option once a variable exceeds what classic format can address.
+    """
+
+    filename = Path(filename)
+
+    # NETCDF4/HDF5 supports int64, but the classic 64-bit-offset format does
+    # not - downcast explicitly here since writing NETCDF4 (unlike writing
+    # classic directly through xarray) doesn't do this coercion automatically,
+    # and nccopy errors on int64. Kept for the NETCDF4 path too: nothing here
+    # needs 64-bit indices, and int32 halves the two largest integer arrays.
+    encoding = {}
+    for var in ds.variables:
+        enc = {"_FillValue": None}
+        dtype = ds[var].dtype
+        if np.issubdtype(dtype, np.integer) and dtype != np.int32:
+            enc["dtype"] = "int32"
+        elif (
+            single_precision
+            and np.issubdtype(dtype, np.floating)
+            and dtype != np.float32
+        ):
+            enc["dtype"] = "float32"
+        if not classic:
+            # Only worth it on the arrays that dominate; the grid-dims and
+            # ni/nj index arrays are too small for chunking overhead to pay off.
+            # mask/frac are near-constant and compress by well over an order of
+            # magnitude; the coordinate and weight arrays are smooth enough to
+            # give back a useful fraction too.
+            if ds[var].size >= _DEFLATE_MIN_SIZE:
+                enc["zlib"] = True
+                enc["complevel"] = _DEFLATE_LEVEL
+        encoding[var] = enc
+
+    if not classic:
+        ds.to_netcdf(filename, format="NETCDF4", encoding=encoding)
+        return
+
+    # NETCDF3_64BIT is required for compatibility with CESM's mapping-file
+    # readers, but writing large fixed-size variables directly in that format
+    # via netCDF4-python/xarray triggers pathological backward-seeking,
+    # read-before-write I/O in the classic-format writer (~17x slower on a
+    # 21.6M-element mesh - confirmed both through xarray and the low-level
+    # netCDF4 API). Writing NETCDF4 (HDF5) first and converting with `nccopy`
+    # avoids that writer entirely and is dramatically faster.
+    _require_nccopy()
+    with tempfile.TemporaryDirectory(dir=filename.parent) as tmpdir:
+        tmp_nc4 = Path(tmpdir) / "tmp_netcdf4.nc"
+        ds.to_netcdf(tmp_nc4, format="NETCDF4", encoding=encoding)
+        subprocess.run(["nccopy", "-6", str(tmp_nc4), str(filename)], check=True)
+
+
+def _extract_classic_subset(src_path, dst_path, variables):
+    """Copy just `variables` out of a netCDF file into a NETCDF3_64BIT file.
+
+    `nccopy -V` takes definitions and data for the listed variables only, and
+    drops every dimension no listed variable uses - so the n_a/n_b geometry
+    dimensions disappear without being named here. Global attributes come
+    across unchanged.
+    """
+    _require_nccopy()
+    subprocess.run(
+        ["nccopy", "-6", "-V", ",".join(variables), str(src_path), str(dst_path)],
+        check=True,
+    )
+
+
+def _set_full_map_attrs(full_path, minimal_name):
+    """Stamp the record-keeping companion's own description into its header.
+
+    Done as an in-place header edit after the file is written, rather than
+    before: the companion shares `ds` with the classic file carved out of it, and
+    HDF5 rewrites an attribute without touching the data section.
+    """
+    with netCDF4.Dataset(full_path, "a") as nc:
+        nc.setncattr(
+            "contents",
+            "all mapping-file variables (record-keeping companion to "
+            f"{minimal_name})",
+        )
+        nc.setncattr(
+            "format_note",
+            "NETCDF4/deflate - this file is not read by CESM, so it is not held "
+            "to the NETCDF3_64BIT format its mapping-file readers require, nor "
+            "to that format's 4 GiB per-variable ceiling.",
+        )
+
+
 def write_mapping_file(
     src_mesh,
     dst_mesh,
@@ -205,6 +361,9 @@ def write_mapping_file(
     weights_esmpy=None,
     weights_coo=None,
     area_normalization=False,
+    minimal=False,
+    full_map_filename=None,
+    single_precision=False,
 ):
     """Based on a given source mesh, destination mesh, and weights, write out an ESMF map file.
 
@@ -226,6 +385,18 @@ def write_mapping_file(
         Regridding method, by default 'bilinear'.
     area_normalization : bool, optional
         Whether to multiply the weights by (area_source / area_destination), by default False.
+    minimal : bool, optional
+        If True, `filename` contains only the variables an ESMF/CESM route handle
+        actually needs (see `MINIMAL_MAP_VARIABLES`), omitting the per-cell source
+        and destination geometry. By default False (write every variable).
+    full_map_filename : str or Path, optional
+        If given, additionally write the complete, all-variables mapping file
+        here, for record keeping, as compressed NETCDF4 rather than the
+        NETCDF3_64BIT `filename` gets. Only meaningful alongside `minimal=True`;
+        passing it with `minimal=False` would just duplicate `filename`.
+    single_precision : bool, optional
+        If True, write 64-bit float variables as 32-bit, halving their on-disk
+        size. Applies to both `filename` and `full_map_filename`.
 
     Returns
     -------
@@ -234,6 +405,12 @@ def write_mapping_file(
 
     if rank() != 0:
         return  # TODO: parallelize this function
+
+    if full_map_filename is not None and not minimal:
+        raise ValueError(
+            "full_map_filename is only meaningful with minimal=True; with "
+            "minimal=False it would be an exact duplicate of filename."
+        )
 
     if isinstance(src_mesh, (str, Path)):
         src_mesh = xr.open_dataset(src_mesh)
@@ -264,76 +441,89 @@ def write_mapping_file(
             weights_coo, coo_matrix
         ), "weights_coo must be a scipy sparse COO matrix"
 
+    # The descriptive geometry is only assembled if some output file will carry
+    # it; the cell areas are needed either way when area_normalization is on.
+    # Skipping it keeps the (n_a, 4) vertex-coordinate reconstruction - by far
+    # the largest intermediate here on a global source mesh - out of memory
+    # entirely for a minimal-only write.
+    write_geometry = (not minimal) or (full_map_filename is not None)
+    need_areas = write_geometry or area_normalization
+
     # Only the (ny, nx) shape of each mesh is needed below - get it directly
     # from element connectivity, without reconstructing full mesh geometry.
     src_nx, src_ny = get_mesh_dimensions(src_mesh)
     dst_nx, dst_ny = get_mesh_dimensions(dst_mesh)
 
+    ds_vars = {}
+
     # 1/3: Source Domain Fields
     # -------------------
 
-    xc_a = xr.DataArray(
-        src_mesh.centerCoords.data[:, 0],
-        dims=["n_a"],
-        attrs={
-            "long_name": "longitude of grid cell center (input)",
-            "units": "degrees east",
-        },
-    )
+    if need_areas:
+        xv_a_data, yv_a_data = _construct_vertex_coords(src_mesh)
+        area_a_data = cell_area_rad(xv_a_data, yv_a_data)
 
-    yc_a = xr.DataArray(
-        src_mesh.centerCoords.data[:, 1],
-        dims=["n_a"],
-        attrs={
-            "long_name": "latitude of grid cell center (input)",
-            "units": "degrees north",
-        },
-    )
+    if write_geometry:
+        ds_vars["xc_a"] = xr.DataArray(
+            src_mesh.centerCoords.data[:, 0],
+            dims=["n_a"],
+            attrs={
+                "long_name": "longitude of grid cell center (input)",
+                "units": "degrees east",
+            },
+        )
 
-    xv_a_data, yv_a_data = _construct_vertex_coords(src_mesh)
+        ds_vars["yc_a"] = xr.DataArray(
+            src_mesh.centerCoords.data[:, 1],
+            dims=["n_a"],
+            attrs={
+                "long_name": "latitude of grid cell center (input)",
+                "units": "degrees north",
+            },
+        )
 
-    xv_a = xr.DataArray(
-        xv_a_data,
-        dims=["n_a", "nv_a"],
-        attrs={
-            "long_name": "longitude of grid cell verticies (input)",
-            "units": "degrees east",
-        },
-    )
+        ds_vars["xv_a"] = xr.DataArray(
+            xv_a_data,
+            dims=["n_a", "nv_a"],
+            attrs={
+                "long_name": "longitude of grid cell verticies (input)",
+                "units": "degrees east",
+            },
+        )
 
-    yv_a = xr.DataArray(
-        yv_a_data,
-        dims=["n_a", "nv_a"],
-        attrs={
-            "long_name": "latitude of grid cell verticies (input)",
-            "units": "degrees north",
-        },
-    )
+        ds_vars["yv_a"] = xr.DataArray(
+            yv_a_data,
+            dims=["n_a", "nv_a"],
+            attrs={
+                "long_name": "latitude of grid cell verticies (input)",
+                "units": "degrees north",
+            },
+        )
 
-    mask_a = xr.DataArray(
-        src_mesh.elementMask.data,
-        dims=["n_a"],
-        attrs={
-            "long_name": "domain mask (input)",
-        },
-    )
+        ds_vars["mask_a"] = xr.DataArray(
+            src_mesh.elementMask.data,
+            dims=["n_a"],
+            attrs={
+                "long_name": "domain mask (input)",
+            },
+        )
 
-    area_a = xr.DataArray(
-        cell_area_rad(xv_a, yv_a),
-        dims=["n_a"],
-        attrs={"long_name": "area of cell (input)", "units": "radians^2"},
-    )
+        ds_vars["area_a"] = xr.DataArray(
+            area_a_data,
+            dims=["n_a"],
+            attrs={"long_name": "area of cell (input)", "units": "radians^2"},
+        )
 
-    frac_a = xr.DataArray(
-        src_mesh.elementMask.data.astype(np.float64),
-        dims=["n_a"],
-        attrs={
-            "long_name": "fraction of domain intersection (input)",
-            #'units': ''
-        },
-    )
+        ds_vars["frac_a"] = xr.DataArray(
+            src_mesh.elementMask.data.astype(np.float64),
+            dims=["n_a"],
+            attrs={
+                "long_name": "fraction of domain intersection (input)",
+                #'units': ''
+            },
+        )
 
-    src_grid_dims = xr.DataArray(
+    ds_vars["src_grid_dims"] = xr.DataArray(
         np.array([src_nx, src_ny]).astype(np.int32),
         dims=["src_grid_rank"],
         # attrs={
@@ -341,81 +531,85 @@ def write_mapping_file(
         # }
     )
 
-    nj_a = xr.DataArray(
-        [i + 1 for i in range(src_ny)],
-        dims=["nj_a"],
-    )
+    if write_geometry:
+        ds_vars["nj_a"] = xr.DataArray(
+            [i + 1 for i in range(src_ny)],
+            dims=["nj_a"],
+        )
 
-    ni_a = xr.DataArray(
-        [i + 1 for i in range(src_nx)],
-        dims=["ni_a"],
-    )
+        ds_vars["ni_a"] = xr.DataArray(
+            [i + 1 for i in range(src_nx)],
+            dims=["ni_a"],
+        )
 
     # 2/3: Destination Domain Fields
     # -------------------
 
-    xc_b = xr.DataArray(
-        dst_mesh.centerCoords.data[:, 0],
-        dims=["n_b"],
-        attrs={
-            "long_name": "longitude of grid cell center (output)",
-            "units": "degrees east",
-        },
-    )
+    if need_areas:
+        xv_b_data, yv_b_data = _construct_vertex_coords(dst_mesh)
+        area_b_data = cell_area_rad(xv_b_data, yv_b_data)
 
-    yc_b = xr.DataArray(
-        dst_mesh.centerCoords.data[:, 1],
-        dims=["n_b"],
-        attrs={
-            "long_name": "latitude of grid cell center (output)",
-            "units": "degrees north",
-        },
-    )
+    if write_geometry:
+        ds_vars["xc_b"] = xr.DataArray(
+            dst_mesh.centerCoords.data[:, 0],
+            dims=["n_b"],
+            attrs={
+                "long_name": "longitude of grid cell center (output)",
+                "units": "degrees east",
+            },
+        )
 
-    xv_b_data, yv_b_data = _construct_vertex_coords(dst_mesh)
+        ds_vars["yc_b"] = xr.DataArray(
+            dst_mesh.centerCoords.data[:, 1],
+            dims=["n_b"],
+            attrs={
+                "long_name": "latitude of grid cell center (output)",
+                "units": "degrees north",
+            },
+        )
 
-    xv_b = xr.DataArray(
-        xv_b_data,
-        dims=["n_b", "nv_b"],
-        attrs={
-            "long_name": "longitude of grid cell verticies (output)",
-            "units": "degrees east",
-        },
-    )
+        ds_vars["xv_b"] = xr.DataArray(
+            xv_b_data,
+            dims=["n_b", "nv_b"],
+            attrs={
+                "long_name": "longitude of grid cell verticies (output)",
+                "units": "degrees east",
+            },
+        )
 
-    yv_b = xr.DataArray(
-        yv_b_data,
-        dims=["n_b", "nv_b"],
-        attrs={
-            "long_name": "latitude of grid cell verticies (output)",
-            "units": "degrees north",
-        },
-    )
+        ds_vars["yv_b"] = xr.DataArray(
+            yv_b_data,
+            dims=["n_b", "nv_b"],
+            attrs={
+                "long_name": "latitude of grid cell verticies (output)",
+                "units": "degrees north",
+            },
+        )
 
-    mask_b = xr.DataArray(
-        dst_mesh.elementMask.data,
-        dims=["n_b"],
-        attrs={
-            "long_name": "domain mask (output)",
-        },
-    )
+        ds_vars["mask_b"] = xr.DataArray(
+            dst_mesh.elementMask.data,
+            dims=["n_b"],
+            attrs={
+                "long_name": "domain mask (output)",
+            },
+        )
 
-    area_b = xr.DataArray(
-        cell_area_rad(xv_b, yv_b),
-        dims=["n_b"],
-        attrs={"long_name": "area of cell (output)", "units": "radians^2"},
-    )
+        ds_vars["area_b"] = xr.DataArray(
+            area_b_data,
+            dims=["n_b"],
+            attrs={"long_name": "area of cell (output)", "units": "radians^2"},
+        )
 
-    frac_b = xr.DataArray(
-        dst_mesh.elementMask.data.astype(np.float64),
-        dims=["n_b"],
-        attrs={
-            "long_name": "fraction of domain intersection (output)",
-            #'units': ''
-        },
-    )
+        ds_vars["frac_b"] = xr.DataArray(
+            dst_mesh.elementMask.data.astype(np.float64),
+            dims=["n_b"],
+            attrs={
+                "long_name": "fraction of domain intersection (output)",
+                #'units': ''
+            },
+        )
 
-    dst_grid_dims = xr.DataArray(
+    ds_vars["dst_grid_dims"] = xr.DataArray(
         np.array([dst_nx, dst_ny]).astype(np.int32),
         dims=["dst_grid_rank"],
         # dst_grid_dimsattrs={
@@ -423,15 +617,16 @@ def write_mapping_file(
         # }
     )
 
-    nj_b = xr.DataArray(
-        [i + 1 for i in range(dst_ny)],
-        dims=["nj_b"],
-    )
+    if write_geometry:
+        ds_vars["nj_b"] = xr.DataArray(
+            [i + 1 for i in range(dst_ny)],
+            dims=["nj_b"],
+        )
 
-    ni_b = xr.DataArray(
-        [i + 1 for i in range(dst_nx)],
-        dims=["ni_b"],
-    )
+        ds_vars["ni_b"] = xr.DataArray(
+            [i + 1 for i in range(dst_nx)],
+            dims=["ni_b"],
+        )
 
     # 3/3: Weights
     # -------------------
@@ -450,7 +645,7 @@ def write_mapping_file(
         row_data = weights_coo.row + 1
 
     if area_normalization:
-        w.data *= area_a.data[col_data - 1] / area_b.data[row_data - 1]
+        w.data *= area_a_data[col_data - 1] / area_b_data[row_data - 1]
 
     S = xr.DataArray(
         w.data,
@@ -478,40 +673,14 @@ def write_mapping_file(
 
     # Drop NaN values from S, col, and row
     non_nan_indices = np.where(~np.isnan(S))[0]
-    S_new = S[non_nan_indices]
-    row_new = row[non_nan_indices]
-    col_new = col[non_nan_indices]
+    ds_vars["S"] = S[non_nan_indices]
+    ds_vars["row"] = row[non_nan_indices]
+    ds_vars["col"] = col[non_nan_indices]
 
     # Create the dataset and write to a netCDF file
     # ------------------------------------------------
 
-    ds = xr.Dataset(
-        {
-            "xc_a": xc_a,
-            "yc_a": yc_a,
-            "xv_a": xv_a,
-            "yv_a": yv_a,
-            "mask_a": mask_a,
-            "area_a": area_a,
-            "frac_a": frac_a,
-            "src_grid_dims": src_grid_dims,
-            "nj_a": nj_a,
-            "ni_a": ni_a,
-            "xc_b": xc_b,
-            "yc_b": yc_b,
-            "xv_b": xv_b,
-            "yv_b": yv_b,
-            "mask_b": mask_b,
-            "area_b": area_b,
-            "frac_b": frac_b,
-            "dst_grid_dims": dst_grid_dims,
-            "nj_b": nj_b,
-            "ni_b": ni_b,
-            "S": S_new,
-            "col": col_new,
-            "row": row_new,
-        }
-    )
+    ds = xr.Dataset(ds_vars)
 
     ds.attrs["title"] = "CESM mapping file generated by mom6_forge"
     # ds.attrs['normalization'] = 'conservative' # todo
@@ -524,34 +693,41 @@ def write_mapping_file(
     if dst_mesh_path := dst_mesh.encoding.get("source"):
         ds.attrs["domain_b"] = dst_mesh_path
 
-    # NETCDF3_64BIT is required for compatibility with CESM's mapping-file
-    # readers, but writing large fixed-size variables directly in that format
-    # via netCDF4-python/xarray triggers pathological backward-seeking,
-    # read-before-write I/O in the classic-format writer (~17x slower on a
-    # 21.6M-element mesh - confirmed both through xarray and the low-level
-    # netCDF4 API). Writing NETCDF4 (HDF5) first and converting with `nccopy`
-    # avoids that writer entirely and is dramatically faster.
-    filename = Path(filename)
-    if shutil.which("nccopy") is None:
-        raise RuntimeError(
-            "write_mapping_file() requires the 'nccopy' command-line tool "
-            "(part of the netCDF-C distribution) on PATH to efficiently "
-            "convert the intermediate NETCDF4 file to NETCDF3_64BIT."
+    if minimal:
+        ds.attrs["contents"] = (
+            "minimal mapping file: only the variables ESMF reads to build a "
+            "route handle (S, row, col + grid dims). Per-cell source and "
+            "destination geometry is omitted - see domain_a/domain_b."
         )
-    with tempfile.TemporaryDirectory(dir=filename.parent) as tmpdir:
-        tmp_nc4 = Path(tmpdir) / "tmp_netcdf4.nc"
-        # NETCDF4/HDF5 supports int64, but the classic 64-bit-offset format
-        # `nccopy -6` converts to does not - downcast explicitly here since
-        # writing NETCDF4 (unlike writing classic directly through xarray)
-        # doesn't do this coercion automatically, and nccopy errors on int64.
-        encoding = {}
-        for var in ds.variables:
-            enc = {"_FillValue": None}
-            if np.issubdtype(ds[var].dtype, np.integer) and ds[var].dtype != np.int32:
-                enc["dtype"] = "int32"
-            encoding[var] = enc
-        ds.to_netcdf(tmp_nc4, format="NETCDF4", encoding=encoding)
-        subprocess.run(["nccopy", "-6", str(tmp_nc4), str(filename)], check=True)
+
+    if full_map_filename is not None:
+        # Write the all-variables file first, as compressed NETCDF4, then carve
+        # the CESM-facing file out of it with `nccopy -6 -V`. Writing the two
+        # independently would serialize the weight arrays to disk three times
+        # (compressed companion, uncompressed classic-conversion temp, final
+        # classic file); this way they are written once compressed and once in
+        # final form, and the subsetting is a streaming C-level copy.
+        #
+        # The companion is NETCDF4 rather than classic because nothing hands it
+        # to CESM: compression is free there, and classic format cannot address
+        # a single variable over 4 GiB at all (S alone is 11.8 GiB for
+        # CrocIndoPacific_112 at rmax=100).
+        #
+        # `ds` still carries the *minimal* file's global attributes at this
+        # point, deliberately: nccopy copies them straight through to the file
+        # it produces, and the companion's own description is applied afterwards
+        # by editing its header in place - cheap in HDF5, whereas growing a
+        # global attribute in an already-written classic file can force the
+        # whole data section to shift.
+        _write_map_netcdf(ds, full_map_filename, single_precision, classic=False)
+        _extract_classic_subset(full_map_filename, filename, MINIMAL_MAP_VARIABLES)
+        _set_full_map_attrs(full_map_filename, Path(filename).name)
+        return
+
+    if minimal:
+        ds = ds[list(MINIMAL_MAP_VARIABLES)]
+
+    _write_map_netcdf(ds, filename, single_precision)
 
 
 def _lon_bbox(lon):
@@ -645,6 +821,9 @@ def generate_ESMF_map_via_xesmf(
     method,
     area_normalization=False,
     map_overlap=True,
+    minimal=False,
+    full_map_filename=None,
+    single_precision=False,
 ):
     """Generate an ESMF mapping file using xesmf.
 
@@ -663,6 +842,12 @@ def generate_ESMF_map_via_xesmf(
     map_overlap : bool
         If True, only map the overlapping area between the source and destination meshes, i.e.,
         zero out the mask in the source mesh that falls outside the rectangle defined by the destination mesh.
+    minimal : bool, optional
+        Write only the variables ESMF needs to `mapping_file`. See `write_mapping_file`.
+    full_map_filename : str or Path, optional
+        Additionally write the all-variables mapping file here. See `write_mapping_file`.
+    single_precision : bool, optional
+        Write 64-bit float variables as 32-bit. See `write_mapping_file`.
     """
 
     src_grid = grid_from_esmf_mesh(src_mesh_path)
@@ -720,6 +905,9 @@ def generate_ESMF_map_via_xesmf(
         weights=regridder.weights,
         filename=mapping_file,
         area_normalization=area_normalization,
+        minimal=minimal,
+        full_map_filename=full_map_filename,
+        single_precision=single_precision,
     )
 
 
@@ -944,6 +1132,9 @@ def gen_rof_maps(
     mapping_file_prefix,
     rmax=None,
     fold=None,
+    minimal=True,
+    save_full_map=True,
+    single_precision=True,
 ):
     """Generate (1) nearest neighbor and (2) smoothed nearest neighbor mapping files
     from a runoff mesh to an ocean mesh.
@@ -963,6 +1154,24 @@ def gen_rof_maps(
         Maximum distance for smoothing weights, in kilometers. If None, no smoothing is applied.
     fold : float, optional
         Fold factor (km) determining the strength of smoothing based on distance. If None, no smoothing is applied.
+    minimal : bool, optional
+        If True (the default), the mapping files CESM reads carry only the
+        variables ESMF needs - S, row, col and the two grid-dims arrays - which on
+        a global runoff source mesh removes gigabytes of per-source-cell geometry
+        that is fully recoverable from the mesh files themselves.
+    save_full_map : bool, optional
+        If True (the default), also write the complete all-variables version of
+        each mapping file alongside it, named `<name>_full.nc`, for record
+        keeping. That companion goes out as compressed NETCDF4 rather than the
+        NETCDF3_64BIT the CESM-facing file has to be: nothing reads it from
+        CESM, so it is neither bound by that format nor by its 4 GiB
+        per-variable ceiling. Ignored when `minimal` is False.
+    single_precision : bool, optional
+        If True (the default), write 64-bit float variables as 32-bit, halving
+        their on-disk size. netCDF converts on read and ESMF_FactorRead reads S
+        into a real(R8) buffer regardless of the on-disk type, so this stays a
+        valid ESMF weight file - and it doubles the headroom before S hits the
+        4 GiB per-variable ceiling of the NETCDF3_64BIT format CESM requires.
     """
 
     print(f"Generating nearest neighbor mapping file...")
@@ -985,6 +1194,7 @@ def gen_rof_maps(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     nn_map_filepath = get_nn_map_filepath(mapping_file_prefix, output_dir)
+    write_full = minimal and save_full_map
 
     generate_ESMF_map_via_xesmf(
         src_mesh_path=rof_mesh_path,
@@ -992,6 +1202,11 @@ def gen_rof_maps(
         mapping_file=nn_map_filepath,
         method="nearest_d2s",
         area_normalization=True,
+        minimal=minimal,
+        full_map_filename=(
+            get_full_map_filepath(nn_map_filepath) if write_full else None
+        ),
+        single_precision=single_precision,
     )
 
     print(f"  Generated nearest mapping file in {(t1:=time()) - t0:.2f} seconds at:")
@@ -1024,11 +1239,10 @@ def gen_rof_maps(
             fold=fold,
         )
 
-        # mesh dimensions
-        rof_nx = len(nn_map.ni_a)
-        rof_ny = len(nn_map.nj_a)
-        ocn_nx = len(nn_map.ni_b)
-        ocn_ny = len(nn_map.nj_b)
+        # mesh dimensions - read from the meshes rather than from the nn map's
+        # ni_a/nj_a/ni_b/nj_b, which a minimal mapping file doesn't carry.
+        rof_nx, rof_ny = get_mesh_dimensions(rof_mesh_path)
+        ocn_nx, ocn_ny = get_mesh_dimensions(ocn_mesh_path)
 
         # Create a COO matrix of the mapping weights
         S_coo = coo_matrix(
@@ -1053,6 +1267,11 @@ def gen_rof_maps(
             filename=nnsm_map_filepath,
             weights_coo=S_smooth,
             area_normalization=False,  # No area normalization for smoothing
+            minimal=minimal,
+            full_map_filename=(
+                get_full_map_filepath(nnsm_map_filepath) if write_full else None
+            ),
+            single_precision=single_precision,
         )
 
         print(f"  Generated smoothed mapping file in {time() - t1:.2f} seconds at:")

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -624,9 +624,18 @@ def generate_ESMF_map_via_xesmf(
     if map_overlap:
         lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(dst_mesh_path)
 
-        # normalize source grid coordinates
+        # Normalize longitude only, to match _get_mesh_bbox's [0, 360) convention
+        # for the bbox it just returned. Latitude must NOT be wrapped: mod 360
+        # turns a negative latitude into a large positive one (-5 -> 355), which
+        # then compares as "north of lat_max" and silently masks out source cells
+        # that really do fall inside the destination domain. That made every
+        # runoff source point below the equator invisible - harmless for a
+        # northern-hemisphere domain, but it dropped ~10% of source rivers for an
+        # equator-straddling domain and masked out *all* of them for a purely
+        # southern one, yielding an empty mapping file. Same reasoning as the
+        # latitude handling in _get_mesh_bbox.
         src_lon = normalize_deg(src_grid["lon"].data)
-        src_lat = normalize_deg(src_grid["lat"].data)
+        src_lat = src_grid["lat"].data
 
         src_grid["mask"].data = np.where(
             (src_lon < lon_min)

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -183,11 +183,8 @@ def _construct_vertex_coords(mesh):
     # are always valid); gather all four slots at once, replacing NaN with a
     # placeholder index of 0, then overwrite the placeholder for triangles by
     # duplicating vertex 2 - matching the fan-out a Python loop would do, but
-    # vectorized. Needed because write_mapping_file() must run this over the
-    # FULL source mesh (tens of millions of elements for the production ROF
-    # mesh) to keep the mapping file's source-domain fields consistent with
-    # the runtime component's own (uncropped) domain - see crop_source_mesh's
-    # docstring in gen_rof_maps().
+    # vectorized. This runs over the full source mesh (tens of millions of
+    # elements for the production ROF mesh), so vectorization matters here.
     is_tri = np.isnan(element_conn[:, 3])
     conn_safe = np.where(np.isnan(element_conn), 0, element_conn).astype(int)
 
@@ -208,19 +205,13 @@ def write_mapping_file(
     weights_esmpy=None,
     weights_coo=None,
     area_normalization=False,
-    src_full_mesh=None,
-    src_crop_window=None,
 ):
     """Based on a given source mesh, destination mesh, and weights, write out an ESMF map file.
 
     Parameters
     ----------
     src_mesh : str, xr.Dataset
-        ESMF mesh object or path to the source ESMF mesh file. If `src_full_mesh`
-        is given, this is only used to compute the weights' index space (e.g.
-        a cropped mesh) - the file's source-domain fields (xc_a, area_a, ...)
-        describe `src_full_mesh` instead. If `src_full_mesh` is None, this mesh
-        is used for everything, as before.
+        ESMF mesh object or path to the source ESMF mesh file.
     dst_mesh : str, xr.Dataset
         ESMF mesh object or path to the destination ESMF mesh file.
     filename : str
@@ -235,24 +226,6 @@ def write_mapping_file(
         Regridding method, by default 'bilinear'.
     area_normalization : bool, optional
         Whether to multiply the weights by (area_source / area_destination), by default False.
-    src_full_mesh : str, xr.Dataset, optional
-        The full, uncropped source mesh, if `src_mesh` is a cropped subset used
-        only to compute weights cheaply. When given, every source-domain field
-        written (xc_a/yc_a/xv_a/yv_a/mask_a/area_a/frac_a/src_grid_dims/nj_a/ni_a)
-        describes this full mesh instead of `src_mesh` - so `n_a` matches
-        whatever mesh the runtime component (e.g. DROF) actually uses as its
-        own domain, not the cropped mesh used only to speed up weight
-        computation. Without this, a mapping file built from a cropped source
-        mesh is dimensionally inconsistent with a component whose registered
-        domain is the uncropped mesh - see `crop_source_mesh` in `gen_rof_maps`.
-    src_crop_window : tuple of (imin, jmin, nx_crop, nx_full), optional
-        Only used with the `weights` (xESMF) path, together with `src_full_mesh`.
-        `weights`' column indices are positions in `src_mesh`'s (cropped) flat
-        raster; this translates them into `src_full_mesh`'s flat raster before
-        writing, using the cropped window's offset within the full mesh.
-        `weights_coo`/`weights_esmpy` column indices don't need this: a
-        smoothing matrix built from a mapping file already written with a
-        `src_full_mesh` is already in full-mesh index space by construction.
 
     Returns
     -------
@@ -266,9 +239,6 @@ def write_mapping_file(
         src_mesh = xr.open_dataset(src_mesh)
     if isinstance(dst_mesh, (str, Path)):
         dst_mesh = xr.open_dataset(dst_mesh)
-    if isinstance(src_full_mesh, (str, Path)):
-        src_full_mesh = xr.open_dataset(src_full_mesh)
-    src_domain_mesh = src_full_mesh if src_full_mesh is not None else src_mesh
 
     if weights is weights_esmpy is weights_coo is None:
         raise ValueError(
@@ -296,14 +266,14 @@ def write_mapping_file(
 
     # Only the (ny, nx) shape of each mesh is needed below - get it directly
     # from element connectivity, without reconstructing full mesh geometry.
-    src_nx, src_ny = get_mesh_dimensions(src_domain_mesh)
+    src_nx, src_ny = get_mesh_dimensions(src_mesh)
     dst_nx, dst_ny = get_mesh_dimensions(dst_mesh)
 
     # 1/3: Source Domain Fields
     # -------------------
 
     xc_a = xr.DataArray(
-        src_domain_mesh.centerCoords.data[:, 0],
+        src_mesh.centerCoords.data[:, 0],
         dims=["n_a"],
         attrs={
             "long_name": "longitude of grid cell center (input)",
@@ -312,7 +282,7 @@ def write_mapping_file(
     )
 
     yc_a = xr.DataArray(
-        src_domain_mesh.centerCoords.data[:, 1],
+        src_mesh.centerCoords.data[:, 1],
         dims=["n_a"],
         attrs={
             "long_name": "latitude of grid cell center (input)",
@@ -320,7 +290,7 @@ def write_mapping_file(
         },
     )
 
-    xv_a_data, yv_a_data = _construct_vertex_coords(src_domain_mesh)
+    xv_a_data, yv_a_data = _construct_vertex_coords(src_mesh)
 
     xv_a = xr.DataArray(
         xv_a_data,
@@ -341,7 +311,7 @@ def write_mapping_file(
     )
 
     mask_a = xr.DataArray(
-        src_domain_mesh.elementMask.data,
+        src_mesh.elementMask.data,
         dims=["n_a"],
         attrs={
             "long_name": "domain mask (input)",
@@ -355,7 +325,7 @@ def write_mapping_file(
     )
 
     frac_a = xr.DataArray(
-        src_domain_mesh.elementMask.data.astype(np.float64),
+        src_mesh.elementMask.data.astype(np.float64),
         dims=["n_a"],
         attrs={
             "long_name": "fraction of domain intersection (input)",
@@ -470,14 +440,6 @@ def write_mapping_file(
         w = weights.data.copy()
         col_data = w.coords[1, :] + 1
         row_data = w.coords[0, :] + 1
-        if src_crop_window is not None:
-            # col_data indexes src_mesh's (cropped) flat raster - translate
-            # into src_domain_mesh's (full) flat raster before this index is
-            # used for anything (area normalization below, or the file itself).
-            imin, jmin, nx_crop, nx_full = src_crop_window
-            local0 = col_data - 1
-            local_i, local_j = local0 % nx_crop, local0 // nx_crop
-            col_data = (local_j + jmin) * nx_full + (local_i + imin) + 1
     elif weights_esmpy is not None:  # esmpy weights
         w = weights_esmpy.S.copy()
         col_data = weights_esmpy.col.data
@@ -557,7 +519,7 @@ def write_mapping_file(
     ds.attrs["history"] = "Generated by mom6_forge"
     ds.attrs["conventions"] = "NCAR-CCSM"
     ds.attrs["date_created"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    if src_mesh_path := src_domain_mesh.encoding.get("source"):
+    if src_mesh_path := src_mesh.encoding.get("source"):
         ds.attrs["domain_a"] = src_mesh_path
     if dst_mesh_path := dst_mesh.encoding.get("source"):
         ds.attrs["domain_b"] = dst_mesh_path
@@ -627,174 +589,6 @@ def _get_mesh_bbox(mesh_path):
     return mesh_lon.min(), mesh_lon.max(), mesh_lat.min(), mesh_lat.max()
 
 
-def _mesh_index_window(mesh_path, lon_min, lon_max, lat_min, lat_max, buffer_deg=0.5):
-    """Find the smallest rectangular index window in `mesh_path`'s (ny, nx) raster
-    covering a lon/lat bounding box (plus a buffer). Shared by
-    `crop_esmf_mesh_to_bbox()` (to do the actual slicing) and `gen_rof_maps()`
-    (to translate cropped-mesh weight indices back into the full mesh's index
-    space afterward) so both agree on the exact same window.
-
-    Parameters
-    ----------
-    mesh_path : str or Path
-        Path to a non-cyclic, non-tripolar, rectangular lat/lon ESMF mesh file
-        (monotonic lon along x, monotonic lat along y).
-    lon_min, lon_max, lat_min, lat_max, buffer_deg :
-        See `crop_esmf_mesh_to_bbox()`.
-
-    Returns
-    -------
-    imin, imax, jmin, jmax, nx, ny : int
-        Index window `[jmin:jmax, imin:imax]` into the mesh's own `(ny, nx)`
-        raster, and the mesh's own full `(nx, ny)`.
-    """
-
-    mesh = xr.open_dataset(mesh_path)
-    nx, ny = get_mesh_dimensions(mesh)
-
-    # Only longitude has a 0/360 wrap ambiguity - latitude must stay unwrapped
-    # (see _get_mesh_bbox).
-    center_lon = normalize_deg(mesh["centerCoords"].data[:, 0]).reshape(ny, nx)
-    center_lat = mesh["centerCoords"].data[:, 1].reshape(ny, nx)
-
-    lon_row = center_lon[0, :]
-    lat_col = center_lat[:, 0]
-    assert np.all(np.diff(lon_row) > 0) or np.all(np.diff(lon_row) < 0), (
-        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
-        "longitude along the x-axis (non-cyclic, non-tripolar meshes only)"
-    )
-    assert np.all(np.diff(lat_col) > 0) or np.all(np.diff(lat_col) < 0), (
-        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
-        "latitude along the y-axis (non-cyclic, non-tripolar meshes only)"
-    )
-
-    lon_lo, lon_hi = lon_min - buffer_deg, lon_max + buffer_deg
-    lat_lo, lat_hi = lat_min - buffer_deg, lat_max + buffer_deg
-
-    i_in_range = np.where((lon_row >= lon_lo) & (lon_row <= lon_hi))[0]
-    j_in_range = np.where((lat_col >= lat_lo) & (lat_col <= lat_hi))[0]
-    assert i_in_range.size > 0 and j_in_range.size > 0, (
-        "crop_esmf_mesh_to_bbox(): no source mesh cells fall within the "
-        "requested bounding box + buffer"
-    )
-    imin, imax = int(i_in_range.min()), int(i_in_range.max()) + 1
-    jmin, jmax = int(j_in_range.min()), int(j_in_range.max()) + 1
-    return imin, imax, jmin, jmax, nx, ny
-
-
-def crop_esmf_mesh_to_bbox(
-    mesh_path, lon_min, lon_max, lat_min, lat_max, output_path, buffer_deg=0.5
-):
-    """Crop a regular-grid ESMF mesh to the smallest rectangular index window
-    covering a lon/lat bounding box (plus a buffer), and write it as a new,
-    self-consistent ESMF mesh file.
-
-    This works directly on the mesh's own fields (centerCoords/elementMask/
-    nodeCoords) via plain reshape and slicing - it never reconstructs full
-    mesh geometry (no supergrid, no dx/dy/area/angle_dx), since none of that
-    is part of the ESMF mesh format or needed here. ``elementConn`` is
-    rebuilt fresh for the cropped rectangle rather than remapped from the
-    original mesh, since a plain rectangular grid's connectivity is fully
-    determined by its shape.
-
-    Parameters
-    ----------
-    mesh_path : str or Path
-        Path to the source ESMF mesh file to crop. Must be a non-cyclic,
-        non-tripolar, rectangular lat/lon mesh (monotonic lon along x,
-        monotonic lat along y).
-    lon_min, lon_max, lat_min, lat_max : float
-        Bounding box (degrees) to crop to - typically the destination mesh's
-        own bounding box, from ``_get_mesh_bbox()``.
-    output_path : str or Path
-        Path to write the cropped ESMF mesh file to.
-    buffer_deg : float, optional
-        Degrees of margin added around the bbox on each side, so the crop
-        window is a strict superset of whatever downstream masking
-        (``map_overlap``) keeps active - the buffer only widens the array
-        bounds, it doesn't change which points end up unmasked. Default 0.5.
-
-    Returns
-    -------
-    output_path : Path
-    """
-
-    assert isinstance(
-        mesh_path, (str, Path)
-    ), "mesh_path must be a path to an existing file"
-    mesh = xr.open_dataset(mesh_path)
-    imin, imax, jmin, jmax, nx, ny = _mesh_index_window(
-        mesh_path, lon_min, lon_max, lat_min, lat_max, buffer_deg=buffer_deg
-    )
-
-    mask_c = mesh["elementMask"].data.reshape(ny, nx)[jmin:jmax, imin:imax]
-    center_lon_c = mesh["centerCoords"].data[:, 0].reshape(ny, nx)[jmin:jmax, imin:imax]
-    center_lat_c = mesh["centerCoords"].data[:, 1].reshape(ny, nx)[jmin:jmax, imin:imax]
-
-    node_lon = mesh["nodeCoords"].data[:, 0].reshape(ny + 1, nx + 1)
-    node_lat = mesh["nodeCoords"].data[:, 1].reshape(ny + 1, nx + 1)
-    node_lon_c = node_lon[jmin : jmax + 1, imin : imax + 1]
-    node_lat_c = node_lat[jmin : jmax + 1, imin : imax + 1]
-
-    ny_c, nx_c = mask_c.shape
-    node_idx = np.arange((ny_c + 1) * (nx_c + 1)).reshape(ny_c + 1, nx_c + 1)
-    element_conn_c = (
-        np.stack(
-            [
-                node_idx[:-1, :-1].ravel(),
-                node_idx[:-1, 1:].ravel(),
-                node_idx[1:, 1:].ravel(),
-                node_idx[1:, :-1].ravel(),
-            ],
-            axis=1,
-        )
-        + 1  # one-based, per ESMF mesh convention
-    ).astype(np.float64)
-
-    lon_units = mesh["centerCoords"].attrs.get("units", "degrees")
-
-    ds_out = xr.Dataset(
-        {
-            "nodeCoords": (
-                ("nodeCount", "coordDim"),
-                np.stack([node_lon_c.ravel(), node_lat_c.ravel()], axis=1),
-                {"units": lon_units},
-            ),
-            "elementConn": (
-                ("elementCount", "maxNodePElement"),
-                element_conn_c,
-                {"long_name": "Node indices that define the element connectivity"},
-            ),
-            "numElementConn": (
-                ("elementCount",),
-                np.full(ny_c * nx_c, 4, dtype=np.int32),
-                {"long_name": "Number of nodes per element"},
-            ),
-            "centerCoords": (
-                ("elementCount", "coordDim"),
-                np.stack([center_lon_c.ravel(), center_lat_c.ravel()], axis=1),
-                {"units": lon_units},
-            ),
-            "elementMask": (
-                ("elementCount",),
-                mask_c.ravel().astype(mesh["elementMask"].dtype),
-                {"units": "unitless"},
-            ),
-        }
-    )
-    ds_out.attrs["gridType"] = "unstructured mesh"
-    ds_out.attrs["history"] = (
-        f"Cropped from {Path(mesh_path).name} to bbox "
-        f"lon=[{lon_min:.3f}, {lon_max:.3f}] lat=[{lat_min:.3f}, {lat_max:.3f}] "
-        f"+ {buffer_deg} deg buffer, by mom6_forge.mapping.crop_esmf_mesh_to_bbox()"
-    )
-
-    output_path = Path(output_path)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    ds_out.to_netcdf(output_path)
-    return output_path
-
-
 def generate_ESMF_map_via_xesmf(
     src_mesh_path,
     dst_mesh_path,
@@ -802,16 +596,13 @@ def generate_ESMF_map_via_xesmf(
     method,
     area_normalization=False,
     map_overlap=True,
-    src_full_mesh_path=None,
-    src_crop_window=None,
 ):
     """Generate an ESMF mapping file using xesmf.
 
     Parameters
     ----------
     src_mesh_path : str or Path
-        Path to the source ESMF mesh file. If `src_full_mesh_path` is given,
-        this may be a cropped subset used only to compute weights cheaply.
+        Path to the source ESMF mesh file.
     dst_mesh_path : str or Path
         Path to the destination ESMF mesh file.
     mapping_file : str or Path
@@ -823,12 +614,6 @@ def generate_ESMF_map_via_xesmf(
     map_overlap : bool
         If True, only map the overlapping area between the source and destination meshes, i.e.,
         zero out the mask in the source mesh that falls outside the rectangle defined by the destination mesh.
-    src_full_mesh_path, src_crop_window :
-        Passed straight through to `write_mapping_file()` - see its docstring.
-        Use when `src_mesh_path` is a cropped subset of `src_full_mesh_path`,
-        so the written mapping file's source-domain fields describe the full
-        mesh (matching the runtime component's own domain) rather than the
-        cropped one used only to speed up weight computation.
     """
 
     src_grid = grid_from_esmf_mesh(src_mesh_path)
@@ -876,8 +661,6 @@ def generate_ESMF_map_via_xesmf(
         weights=regridder.weights,
         filename=mapping_file,
         area_normalization=area_normalization,
-        src_full_mesh=src_full_mesh_path,
-        src_crop_window=src_crop_window,
     )
 
 
@@ -1102,8 +885,6 @@ def gen_rof_maps(
     mapping_file_prefix,
     rmax=None,
     fold=None,
-    crop_source_mesh=True,
-    crop_buffer_deg=0.5,
 ):
     """Generate (1) nearest neighbor and (2) smoothed nearest neighbor mapping files
     from a runoff mesh to an ocean mesh.
@@ -1123,21 +904,6 @@ def gen_rof_maps(
         Maximum distance for smoothing weights, in kilometers. If None, no smoothing is applied.
     fold : float, optional
         Fold factor (km) determining the strength of smoothing based on distance. If None, no smoothing is applied.
-    crop_source_mesh : bool, optional
-        If True (default), crop the ROF source mesh down to a rectangular window
-        around the ocean mesh's bounding box (see `crop_esmf_mesh_to_bbox`) before
-        computing regrid weights - this is what makes generation tractable for a
-        full-size production ROF mesh. This is purely an internal speed-up: the
-        written mapping file's source-domain fields (`xc_a`/`area_a`/`mask_a`/
-        `src_grid_dims`/`n_a`/...) always describe the FULL, uncropped
-        `rof_mesh_path` mesh, matching whatever mesh the runtime component
-        (e.g. DROF) actually declares as its own domain - cropping never
-        changes what mesh the output file claims to be. Disable only to
-        compare against the (much slower, for a large mesh) fully-uncropped
-        computation path.
-    crop_buffer_deg : float, optional
-        Buffer (degrees) added around the ocean mesh's bounding box when cropping.
-        Only used if `crop_source_mesh` is True. Default 0.5.
     """
 
     print(f"Generating nearest neighbor mapping file...")
@@ -1159,38 +925,6 @@ def gen_rof_maps(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    full_rof_mesh_path = rof_mesh_path
-    src_crop_window = None
-    if crop_source_mesh:
-        print(f"Cropping ROF source mesh to ocean mesh bounding box...")
-        lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(ocn_mesh_path)
-        imin, imax, jmin, jmax, nx_full, ny_full = _mesh_index_window(
-            full_rof_mesh_path,
-            lon_min,
-            lon_max,
-            lat_min,
-            lat_max,
-            buffer_deg=crop_buffer_deg,
-        )
-        rof_mesh_path = crop_esmf_mesh_to_bbox(
-            full_rof_mesh_path,
-            lon_min,
-            lon_max,
-            lat_min,
-            lat_max,
-            output_dir / f"{mapping_file_prefix}_rof_mesh_cropped.nc",
-            buffer_deg=crop_buffer_deg,
-        )
-        # Weights are computed on the small cropped mesh (cheap), but the
-        # mapping file's source-domain fields must describe the FULL mesh -
-        # that's what the runtime component (e.g. DROF) actually declares as
-        # its own domain via ROF_DOMAIN_MESH, and CMEPS's remap requires the
-        # map's n_a to match that domain's element count exactly. Cropping
-        # is purely an internal speed-up for computing the weights; it must
-        # not change what mesh the written file claims to describe.
-        src_crop_window = (imin, jmin, imax - imin, nx_full)
-        print(f"  Cropped ROF mesh written to {rof_mesh_path}")
-
     nn_map_filepath = get_nn_map_filepath(mapping_file_prefix, output_dir)
 
     generate_ESMF_map_via_xesmf(
@@ -1199,8 +933,6 @@ def gen_rof_maps(
         mapping_file=nn_map_filepath,
         method="nearest_d2s",
         area_normalization=True,
-        src_full_mesh_path=full_rof_mesh_path if crop_source_mesh else None,
-        src_crop_window=src_crop_window,
     )
 
     print(f"  Generated nearest mapping file in {(t1:=time()) - t0:.2f} seconds at:")
@@ -1262,12 +994,6 @@ def gen_rof_maps(
             filename=nnsm_map_filepath,
             weights_coo=S_smooth,
             area_normalization=False,  # No area normalization for smoothing
-            # S_smooth's column indices are already in full-mesh index space:
-            # they come from S_coo, built directly from nn_map's own row/col/
-            # ni_a/nj_a - which the nn_map write above already wrote in full-
-            # mesh space (no separate remap needed here, only the matching
-            # full-mesh descriptive fields for consistency with the nn map).
-            src_full_mesh=full_rof_mesh_path if crop_source_mesh else None,
         )
 
         print(f"  Generated smoothed mapping file in {time() - t1:.2f} seconds at:")

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -173,23 +173,26 @@ def _construct_vertex_coords(mesh):
         The vertex coordinates in the y-direction.
     """
 
-    xv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
-    yv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
-
     element_conn = mesh.elementConn.data - 1  # one-based to zero-based indexing
     node_coords = mesh.nodeCoords.data
 
-    for e, nodes in enumerate(element_conn):
-        if np.isnan(nodes[3]):
-            valid_nodes = nodes[:3][~np.isnan(nodes[:3])].astype(int)
-            xv_data[e, :3] = node_coords[valid_nodes, 0]
-            xv_data[e, 3] = xv_data[e, 2]
-            yv_data[e, :3] = node_coords[valid_nodes, 1]
-            yv_data[e, 3] = yv_data[e, 2]
-        else:
-            valid_nodes = nodes.astype(int)
-            xv_data[e, :] = node_coords[valid_nodes, 0]
-            yv_data[e, :] = node_coords[valid_nodes, 1]
+    # Triangular elements store NaN in the 4th connectivity slot (nodes 0-2
+    # are always valid); gather all four slots at once, replacing NaN with a
+    # placeholder index of 0, then overwrite the placeholder for triangles by
+    # duplicating vertex 2 - matching the fan-out a Python loop would do, but
+    # vectorized. Needed because write_mapping_file() must run this over the
+    # FULL source mesh (tens of millions of elements for the production ROF
+    # mesh) to keep the mapping file's source-domain fields consistent with
+    # the runtime component's own (uncropped) domain - see crop_source_mesh's
+    # docstring in gen_rof_maps().
+    is_tri = np.isnan(element_conn[:, 3])
+    conn_safe = np.where(np.isnan(element_conn), 0, element_conn).astype(int)
+
+    xv_data = node_coords[conn_safe, 0]
+    yv_data = node_coords[conn_safe, 1]
+
+    xv_data[is_tri, 3] = xv_data[is_tri, 2]
+    yv_data[is_tri, 3] = yv_data[is_tri, 2]
 
     return xv_data, yv_data
 
@@ -202,13 +205,19 @@ def write_mapping_file(
     weights_esmpy=None,
     weights_coo=None,
     area_normalization=False,
+    src_full_mesh=None,
+    src_crop_window=None,
 ):
     """Based on a given source mesh, destination mesh, and weights, write out an ESMF map file.
 
     Parameters
     ----------
     src_mesh : str, xr.Dataset
-        ESMF mesh object or path to the source ESMF mesh file.
+        ESMF mesh object or path to the source ESMF mesh file. If `src_full_mesh`
+        is given, this is only used to compute the weights' index space (e.g.
+        a cropped mesh) - the file's source-domain fields (xc_a, area_a, ...)
+        describe `src_full_mesh` instead. If `src_full_mesh` is None, this mesh
+        is used for everything, as before.
     dst_mesh : str, xr.Dataset
         ESMF mesh object or path to the destination ESMF mesh file.
     filename : str
@@ -223,6 +232,24 @@ def write_mapping_file(
         Regridding method, by default 'bilinear'.
     area_normalization : bool, optional
         Whether to multiply the weights by (area_source / area_destination), by default False.
+    src_full_mesh : str, xr.Dataset, optional
+        The full, uncropped source mesh, if `src_mesh` is a cropped subset used
+        only to compute weights cheaply. When given, every source-domain field
+        written (xc_a/yc_a/xv_a/yv_a/mask_a/area_a/frac_a/src_grid_dims/nj_a/ni_a)
+        describes this full mesh instead of `src_mesh` - so `n_a` matches
+        whatever mesh the runtime component (e.g. DROF) actually uses as its
+        own domain, not the cropped mesh used only to speed up weight
+        computation. Without this, a mapping file built from a cropped source
+        mesh is dimensionally inconsistent with a component whose registered
+        domain is the uncropped mesh - see `crop_source_mesh` in `gen_rof_maps`.
+    src_crop_window : tuple of (imin, jmin, nx_crop, nx_full), optional
+        Only used with the `weights` (xESMF) path, together with `src_full_mesh`.
+        `weights`' column indices are positions in `src_mesh`'s (cropped) flat
+        raster; this translates them into `src_full_mesh`'s flat raster before
+        writing, using the cropped window's offset within the full mesh.
+        `weights_coo`/`weights_esmpy` column indices don't need this: a
+        smoothing matrix built from a mapping file already written with a
+        `src_full_mesh` is already in full-mesh index space by construction.
 
     Returns
     -------
@@ -236,6 +263,9 @@ def write_mapping_file(
         src_mesh = xr.open_dataset(src_mesh)
     if isinstance(dst_mesh, (str, Path)):
         dst_mesh = xr.open_dataset(dst_mesh)
+    if isinstance(src_full_mesh, (str, Path)):
+        src_full_mesh = xr.open_dataset(src_full_mesh)
+    src_domain_mesh = src_full_mesh if src_full_mesh is not None else src_mesh
 
     if weights is weights_esmpy is weights_coo is None:
         raise ValueError(
@@ -263,14 +293,14 @@ def write_mapping_file(
 
     # Only the (ny, nx) shape of each mesh is needed below - get it directly
     # from element connectivity, without reconstructing full mesh geometry.
-    src_nx, src_ny = get_mesh_dimensions(src_mesh)
+    src_nx, src_ny = get_mesh_dimensions(src_domain_mesh)
     dst_nx, dst_ny = get_mesh_dimensions(dst_mesh)
 
     # 1/3: Source Domain Fields
     # -------------------
 
     xc_a = xr.DataArray(
-        src_mesh.centerCoords.data[:, 0],
+        src_domain_mesh.centerCoords.data[:, 0],
         dims=["n_a"],
         attrs={
             "long_name": "longitude of grid cell center (input)",
@@ -279,7 +309,7 @@ def write_mapping_file(
     )
 
     yc_a = xr.DataArray(
-        src_mesh.centerCoords.data[:, 1],
+        src_domain_mesh.centerCoords.data[:, 1],
         dims=["n_a"],
         attrs={
             "long_name": "latitude of grid cell center (input)",
@@ -287,7 +317,7 @@ def write_mapping_file(
         },
     )
 
-    xv_a_data, yv_a_data = _construct_vertex_coords(src_mesh)
+    xv_a_data, yv_a_data = _construct_vertex_coords(src_domain_mesh)
 
     xv_a = xr.DataArray(
         xv_a_data,
@@ -308,7 +338,7 @@ def write_mapping_file(
     )
 
     mask_a = xr.DataArray(
-        src_mesh.elementMask.data,
+        src_domain_mesh.elementMask.data,
         dims=["n_a"],
         attrs={
             "long_name": "domain mask (input)",
@@ -322,7 +352,7 @@ def write_mapping_file(
     )
 
     frac_a = xr.DataArray(
-        src_mesh.elementMask.data.astype(np.float64),
+        src_domain_mesh.elementMask.data.astype(np.float64),
         dims=["n_a"],
         attrs={
             "long_name": "fraction of domain intersection (input)",
@@ -437,6 +467,14 @@ def write_mapping_file(
         w = weights.data.copy()
         col_data = w.coords[1, :] + 1
         row_data = w.coords[0, :] + 1
+        if src_crop_window is not None:
+            # col_data indexes src_mesh's (cropped) flat raster - translate
+            # into src_domain_mesh's (full) flat raster before this index is
+            # used for anything (area normalization below, or the file itself).
+            imin, jmin, nx_crop, nx_full = src_crop_window
+            local0 = col_data - 1
+            local_i, local_j = local0 % nx_crop, local0 // nx_crop
+            col_data = (local_j + jmin) * nx_full + (local_i + imin) + 1
     elif weights_esmpy is not None:  # esmpy weights
         w = weights_esmpy.S.copy()
         col_data = weights_esmpy.col.data
@@ -516,7 +554,7 @@ def write_mapping_file(
     ds.attrs["history"] = "Generated by mom6_forge"
     ds.attrs["conventions"] = "NCAR-CCSM"
     ds.attrs["date_created"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    if src_mesh_path := src_mesh.encoding.get("source"):
+    if src_mesh_path := src_domain_mesh.encoding.get("source"):
         ds.attrs["domain_a"] = src_mesh_path
     if dst_mesh_path := dst_mesh.encoding.get("source"):
         ds.attrs["domain_b"] = dst_mesh_path
@@ -563,6 +601,61 @@ def _get_mesh_bbox(mesh_path):
     return mesh_lon.min(), mesh_lon.max(), mesh_lat.min(), mesh_lat.max()
 
 
+def _mesh_index_window(mesh_path, lon_min, lon_max, lat_min, lat_max, buffer_deg=0.5):
+    """Find the smallest rectangular index window in `mesh_path`'s (ny, nx) raster
+    covering a lon/lat bounding box (plus a buffer). Shared by
+    `crop_esmf_mesh_to_bbox()` (to do the actual slicing) and `gen_rof_maps()`
+    (to translate cropped-mesh weight indices back into the full mesh's index
+    space afterward) so both agree on the exact same window.
+
+    Parameters
+    ----------
+    mesh_path : str or Path
+        Path to a non-cyclic, non-tripolar, rectangular lat/lon ESMF mesh file
+        (monotonic lon along x, monotonic lat along y).
+    lon_min, lon_max, lat_min, lat_max, buffer_deg :
+        See `crop_esmf_mesh_to_bbox()`.
+
+    Returns
+    -------
+    imin, imax, jmin, jmax, nx, ny : int
+        Index window `[jmin:jmax, imin:imax]` into the mesh's own `(ny, nx)`
+        raster, and the mesh's own full `(nx, ny)`.
+    """
+
+    mesh = xr.open_dataset(mesh_path)
+    nx, ny = get_mesh_dimensions(mesh)
+
+    # Only longitude has a 0/360 wrap ambiguity - latitude must stay unwrapped
+    # (see _get_mesh_bbox).
+    center_lon = normalize_deg(mesh["centerCoords"].data[:, 0]).reshape(ny, nx)
+    center_lat = mesh["centerCoords"].data[:, 1].reshape(ny, nx)
+
+    lon_row = center_lon[0, :]
+    lat_col = center_lat[:, 0]
+    assert np.all(np.diff(lon_row) > 0) or np.all(np.diff(lon_row) < 0), (
+        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
+        "longitude along the x-axis (non-cyclic, non-tripolar meshes only)"
+    )
+    assert np.all(np.diff(lat_col) > 0) or np.all(np.diff(lat_col) < 0), (
+        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
+        "latitude along the y-axis (non-cyclic, non-tripolar meshes only)"
+    )
+
+    lon_lo, lon_hi = lon_min - buffer_deg, lon_max + buffer_deg
+    lat_lo, lat_hi = lat_min - buffer_deg, lat_max + buffer_deg
+
+    i_in_range = np.where((lon_row >= lon_lo) & (lon_row <= lon_hi))[0]
+    j_in_range = np.where((lat_col >= lat_lo) & (lat_col <= lat_hi))[0]
+    assert i_in_range.size > 0 and j_in_range.size > 0, (
+        "crop_esmf_mesh_to_bbox(): no source mesh cells fall within the "
+        "requested bounding box + buffer"
+    )
+    imin, imax = int(i_in_range.min()), int(i_in_range.max()) + 1
+    jmin, jmax = int(j_in_range.min()), int(j_in_range.max()) + 1
+    return imin, imax, jmin, jmax, nx, ny
+
+
 def crop_esmf_mesh_to_bbox(
     mesh_path, lon_min, lon_max, lat_min, lat_max, output_path, buffer_deg=0.5
 ):
@@ -604,35 +697,9 @@ def crop_esmf_mesh_to_bbox(
         mesh_path, (str, Path)
     ), "mesh_path must be a path to an existing file"
     mesh = xr.open_dataset(mesh_path)
-    nx, ny = get_mesh_dimensions(mesh)
-
-    # Only longitude has a 0/360 wrap ambiguity - latitude must stay unwrapped
-    # (see _get_mesh_bbox).
-    center_lon = normalize_deg(mesh["centerCoords"].data[:, 0]).reshape(ny, nx)
-    center_lat = mesh["centerCoords"].data[:, 1].reshape(ny, nx)
-
-    lon_row = center_lon[0, :]
-    lat_col = center_lat[:, 0]
-    assert np.all(np.diff(lon_row) > 0) or np.all(np.diff(lon_row) < 0), (
-        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
-        "longitude along the x-axis (non-cyclic, non-tripolar meshes only)"
+    imin, imax, jmin, jmax, nx, ny = _mesh_index_window(
+        mesh_path, lon_min, lon_max, lat_min, lat_max, buffer_deg=buffer_deg
     )
-    assert np.all(np.diff(lat_col) > 0) or np.all(np.diff(lat_col) < 0), (
-        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
-        "latitude along the y-axis (non-cyclic, non-tripolar meshes only)"
-    )
-
-    lon_lo, lon_hi = lon_min - buffer_deg, lon_max + buffer_deg
-    lat_lo, lat_hi = lat_min - buffer_deg, lat_max + buffer_deg
-
-    i_in_range = np.where((lon_row >= lon_lo) & (lon_row <= lon_hi))[0]
-    j_in_range = np.where((lat_col >= lat_lo) & (lat_col <= lat_hi))[0]
-    assert i_in_range.size > 0 and j_in_range.size > 0, (
-        "crop_esmf_mesh_to_bbox(): no source mesh cells fall within the "
-        "requested bounding box + buffer"
-    )
-    imin, imax = int(i_in_range.min()), int(i_in_range.max()) + 1
-    jmin, jmax = int(j_in_range.min()), int(j_in_range.max()) + 1
 
     mask_c = mesh["elementMask"].data.reshape(ny, nx)[jmin:jmax, imin:imax]
     center_lon_c = mesh["centerCoords"].data[:, 0].reshape(ny, nx)[jmin:jmax, imin:imax]
@@ -709,13 +776,16 @@ def generate_ESMF_map_via_xesmf(
     method,
     area_normalization=False,
     map_overlap=True,
+    src_full_mesh_path=None,
+    src_crop_window=None,
 ):
     """Generate an ESMF mapping file using xesmf.
 
     Parameters
     ----------
     src_mesh_path : str or Path
-        Path to the source ESMF mesh file.
+        Path to the source ESMF mesh file. If `src_full_mesh_path` is given,
+        this may be a cropped subset used only to compute weights cheaply.
     dst_mesh_path : str or Path
         Path to the destination ESMF mesh file.
     mapping_file : str or Path
@@ -727,6 +797,12 @@ def generate_ESMF_map_via_xesmf(
     map_overlap : bool
         If True, only map the overlapping area between the source and destination meshes, i.e.,
         zero out the mask in the source mesh that falls outside the rectangle defined by the destination mesh.
+    src_full_mesh_path, src_crop_window :
+        Passed straight through to `write_mapping_file()` - see its docstring.
+        Use when `src_mesh_path` is a cropped subset of `src_full_mesh_path`,
+        so the written mapping file's source-domain fields describe the full
+        mesh (matching the runtime component's own domain) rather than the
+        cropped one used only to speed up weight computation.
     """
 
     src_grid = grid_from_esmf_mesh(src_mesh_path)
@@ -774,6 +850,8 @@ def generate_ESMF_map_via_xesmf(
         weights=regridder.weights,
         filename=mapping_file,
         area_normalization=area_normalization,
+        src_full_mesh=src_full_mesh_path,
+        src_crop_window=src_crop_window,
     )
 
 
@@ -1022,8 +1100,15 @@ def gen_rof_maps(
     crop_source_mesh : bool, optional
         If True (default), crop the ROF source mesh down to a rectangular window
         around the ocean mesh's bounding box (see `crop_esmf_mesh_to_bbox`) before
-        generating maps. This is what makes generation tractable for a full-size
-        production ROF mesh; disable only to compare against the uncropped path.
+        computing regrid weights - this is what makes generation tractable for a
+        full-size production ROF mesh. This is purely an internal speed-up: the
+        written mapping file's source-domain fields (`xc_a`/`area_a`/`mask_a`/
+        `src_grid_dims`/`n_a`/...) always describe the FULL, uncropped
+        `rof_mesh_path` mesh, matching whatever mesh the runtime component
+        (e.g. DROF) actually declares as its own domain - cropping never
+        changes what mesh the output file claims to be. Disable only to
+        compare against the (much slower, for a large mesh) fully-uncropped
+        computation path.
     crop_buffer_deg : float, optional
         Buffer (degrees) added around the ocean mesh's bounding box when cropping.
         Only used if `crop_source_mesh` is True. Default 0.5.
@@ -1048,11 +1133,21 @@ def gen_rof_maps(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    full_rof_mesh_path = rof_mesh_path
+    src_crop_window = None
     if crop_source_mesh:
         print(f"Cropping ROF source mesh to ocean mesh bounding box...")
         lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(ocn_mesh_path)
+        imin, imax, jmin, jmax, nx_full, ny_full = _mesh_index_window(
+            full_rof_mesh_path,
+            lon_min,
+            lon_max,
+            lat_min,
+            lat_max,
+            buffer_deg=crop_buffer_deg,
+        )
         rof_mesh_path = crop_esmf_mesh_to_bbox(
-            rof_mesh_path,
+            full_rof_mesh_path,
             lon_min,
             lon_max,
             lat_min,
@@ -1060,6 +1155,14 @@ def gen_rof_maps(
             output_dir / f"{mapping_file_prefix}_rof_mesh_cropped.nc",
             buffer_deg=crop_buffer_deg,
         )
+        # Weights are computed on the small cropped mesh (cheap), but the
+        # mapping file's source-domain fields must describe the FULL mesh -
+        # that's what the runtime component (e.g. DROF) actually declares as
+        # its own domain via ROF_DOMAIN_MESH, and CMEPS's remap requires the
+        # map's n_a to match that domain's element count exactly. Cropping
+        # is purely an internal speed-up for computing the weights; it must
+        # not change what mesh the written file claims to describe.
+        src_crop_window = (imin, jmin, imax - imin, nx_full)
         print(f"  Cropped ROF mesh written to {rof_mesh_path}")
 
     nn_map_filepath = get_nn_map_filepath(mapping_file_prefix, output_dir)
@@ -1070,6 +1173,8 @@ def gen_rof_maps(
         mapping_file=nn_map_filepath,
         method="nearest_d2s",
         area_normalization=True,
+        src_full_mesh_path=full_rof_mesh_path if crop_source_mesh else None,
+        src_crop_window=src_crop_window,
     )
 
     print(f"  Generated nearest mapping file in {(t1:=time()) - t0:.2f} seconds at:")
@@ -1131,6 +1236,12 @@ def gen_rof_maps(
             filename=nnsm_map_filepath,
             weights_coo=S_smooth,
             area_normalization=False,  # No area normalization for smoothing
+            # S_smooth's column indices are already in full-mesh index space:
+            # they come from S_coo, built directly from nn_map's own row/col/
+            # ni_a/nj_a - which the nn_map write above already wrote in full-
+            # mesh space (no separate remap needed here, only the matching
+            # full-mesh descriptive fields for consistency with the nn map).
+            src_full_mesh=full_rof_mesh_path if crop_source_mesh else None,
         )
 
         print(f"  Generated smoothed mapping file in {time() - t1:.2f} seconds at:")

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -2,6 +2,9 @@
 
 import os
 import argparse
+import shutil
+import subprocess
+import tempfile
 import xarray as xr
 import numpy as np
 import datetime
@@ -559,11 +562,34 @@ def write_mapping_file(
     if dst_mesh_path := dst_mesh.encoding.get("source"):
         ds.attrs["domain_b"] = dst_mesh_path
 
-    ds.to_netcdf(
-        filename,
-        format="NETCDF3_64BIT",
-        encoding={var: {"_FillValue": None} for var in ds.data_vars},
-    )
+    # NETCDF3_64BIT is required for compatibility with CESM's mapping-file
+    # readers, but writing large fixed-size variables directly in that format
+    # via netCDF4-python/xarray triggers pathological backward-seeking,
+    # read-before-write I/O in the classic-format writer (~17x slower on a
+    # 21.6M-element mesh - confirmed both through xarray and the low-level
+    # netCDF4 API). Writing NETCDF4 (HDF5) first and converting with `nccopy`
+    # avoids that writer entirely and is dramatically faster.
+    filename = Path(filename)
+    if shutil.which("nccopy") is None:
+        raise RuntimeError(
+            "write_mapping_file() requires the 'nccopy' command-line tool "
+            "(part of the netCDF-C distribution) on PATH to efficiently "
+            "convert the intermediate NETCDF4 file to NETCDF3_64BIT."
+        )
+    with tempfile.TemporaryDirectory(dir=filename.parent) as tmpdir:
+        tmp_nc4 = Path(tmpdir) / "tmp_netcdf4.nc"
+        # NETCDF4/HDF5 supports int64, but the classic 64-bit-offset format
+        # `nccopy -6` converts to does not - downcast explicitly here since
+        # writing NETCDF4 (unlike writing classic directly through xarray)
+        # doesn't do this coercion automatically, and nccopy errors on int64.
+        encoding = {}
+        for var in ds.variables:
+            enc = {"_FillValue": None}
+            if np.issubdtype(ds[var].dtype, np.integer) and ds[var].dtype != np.int32:
+                enc["dtype"] = "int32"
+            encoding[var] = enc
+        ds.to_netcdf(tmp_nc4, format="NETCDF4", encoding=encoding)
+        subprocess.run(["nccopy", "-6", str(tmp_nc4), str(filename)], check=True)
 
 
 def _get_mesh_bbox(mesh_path):

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -173,23 +173,22 @@ def _construct_vertex_coords(mesh):
         The vertex coordinates in the y-direction.
     """
 
-    xv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
-    yv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
-
     element_conn = mesh.elementConn.data - 1  # one-based to zero-based indexing
     node_coords = mesh.nodeCoords.data
 
-    for e, nodes in enumerate(element_conn):
-        if np.isnan(nodes[3]):
-            valid_nodes = nodes[:3][~np.isnan(nodes[:3])].astype(int)
-            xv_data[e, :3] = node_coords[valid_nodes, 0]
-            xv_data[e, 3] = xv_data[e, 2]
-            yv_data[e, :3] = node_coords[valid_nodes, 1]
-            yv_data[e, 3] = yv_data[e, 2]
-        else:
-            valid_nodes = nodes.astype(int)
-            xv_data[e, :] = node_coords[valid_nodes, 0]
-            yv_data[e, :] = node_coords[valid_nodes, 1]
+    # Triangular elements store NaN in the 4th connectivity slot (nodes 0-2
+    # are always valid); gather all four slots at once, replacing NaN with a
+    # placeholder index of 0, then overwrite the placeholder for triangles by
+    # duplicating vertex 2 - matching the fan-out a Python loop would do, but
+    # vectorized.
+    is_tri = np.isnan(element_conn[:, 3])
+    conn_safe = np.where(np.isnan(element_conn), 0, element_conn).astype(int)
+
+    xv_data = node_coords[conn_safe, 0]
+    yv_data = node_coords[conn_safe, 1]
+
+    xv_data[is_tri, 3] = xv_data[is_tri, 2]
+    yv_data[is_tri, 3] = yv_data[is_tri, 2]
 
     return xv_data, yv_data
 
@@ -261,11 +260,10 @@ def write_mapping_file(
             weights_coo, coo_matrix
         ), "weights_coo must be a scipy sparse COO matrix"
 
-    # From 1D ESMF mesh to 2D grid
-    from mom6_forge.topo import Topo
-
-    src_topo = Topo.from_esmf_mesh(src_mesh)
-    dst_topo = Topo.from_esmf_mesh(dst_mesh)
+    # Only the (ny, nx) shape of each mesh is needed below - get it directly
+    # from element connectivity, without reconstructing full mesh geometry.
+    src_nx, src_ny = get_mesh_dimensions(src_mesh)
+    dst_nx, dst_ny = get_mesh_dimensions(dst_mesh)
 
     # 1/3: Source Domain Fields
     # -------------------
@@ -332,7 +330,7 @@ def write_mapping_file(
     )
 
     src_grid_dims = xr.DataArray(
-        np.array(src_topo.tmask.shape[::-1]).astype(np.int32),
+        np.array([src_nx, src_ny]).astype(np.int32),
         dims=["src_grid_rank"],
         # attrs={
         #    'long_name': 'dimensions of the source grid',
@@ -340,12 +338,12 @@ def write_mapping_file(
     )
 
     nj_a = xr.DataArray(
-        [i + 1 for i in range(src_topo.tmask.shape[0])],
+        [i + 1 for i in range(src_ny)],
         dims=["nj_a"],
     )
 
     ni_a = xr.DataArray(
-        [i + 1 for i in range(src_topo.tmask.shape[1])],
+        [i + 1 for i in range(src_nx)],
         dims=["ni_a"],
     )
 
@@ -414,7 +412,7 @@ def write_mapping_file(
     )
 
     dst_grid_dims = xr.DataArray(
-        np.array(dst_topo.tmask.shape[::-1]).astype(np.int32),
+        np.array([dst_nx, dst_ny]).astype(np.int32),
         dims=["dst_grid_rank"],
         # dst_grid_dimsattrs={
         #    'long_name': 'dimensions of the destination grid',
@@ -422,12 +420,12 @@ def write_mapping_file(
     )
 
     nj_b = xr.DataArray(
-        [i + 1 for i in range(dst_topo.tmask.shape[0])],
+        [i + 1 for i in range(dst_ny)],
         dims=["nj_b"],
     )
 
     ni_b = xr.DataArray(
-        [i + 1 for i in range(dst_topo.tmask.shape[1])],
+        [i + 1 for i in range(dst_nx)],
         dims=["ni_b"],
     )
 
@@ -529,6 +527,180 @@ def write_mapping_file(
     )
 
 
+def _get_mesh_bbox(mesh_path):
+    """Compute the lon/lat bounding box (degrees, normalized to [0, 360)) covered
+    by an ESMF mesh's nodes.
+
+    Parameters
+    ----------
+    mesh_path : str or Path
+        Path to an ESMF mesh file.
+
+    Returns
+    -------
+    lon_min, lon_max, lat_min, lat_max : float
+    """
+
+    assert isinstance(
+        mesh_path, (str, Path)
+    ), "mesh_path must be a path to an existing file"
+    assert Path(
+        mesh_path
+    ).exists(), "mesh_path must point to an existing ESMF mesh file"
+    mesh = xr.open_dataset(mesh_path)
+    assert (
+        "units" in mesh["centerCoords"].attrs
+    ), "centerCoords must have 'units' attribute"
+    assert (
+        "degrees" in mesh["centerCoords"].attrs["units"]
+    ), "_get_mesh_bbox() expects centerCoords in degrees"
+    # Only longitude has a 0/360 wrap ambiguity to normalize away - latitude is
+    # already well-defined and must not be wrapped (mod 360 would corrupt any
+    # negative latitude, e.g. -6.95 -> 353.05).
+    mesh_lon = normalize_deg(mesh["nodeCoords"].data[:, 0])
+    mesh_lat = mesh["nodeCoords"].data[:, 1]
+    return mesh_lon.min(), mesh_lon.max(), mesh_lat.min(), mesh_lat.max()
+
+
+def crop_esmf_mesh_to_bbox(
+    mesh_path, lon_min, lon_max, lat_min, lat_max, output_path, buffer_deg=0.5
+):
+    """Crop a regular-grid ESMF mesh to the smallest rectangular index window
+    covering a lon/lat bounding box (plus a buffer), and write it as a new,
+    self-consistent ESMF mesh file.
+
+    This works directly on the mesh's own fields (centerCoords/elementMask/
+    nodeCoords) via plain reshape and slicing - it never reconstructs full
+    mesh geometry (no supergrid, no dx/dy/area/angle_dx), since none of that
+    is part of the ESMF mesh format or needed here. ``elementConn`` is
+    rebuilt fresh for the cropped rectangle rather than remapped from the
+    original mesh, since a plain rectangular grid's connectivity is fully
+    determined by its shape.
+
+    Parameters
+    ----------
+    mesh_path : str or Path
+        Path to the source ESMF mesh file to crop. Must be a non-cyclic,
+        non-tripolar, rectangular lat/lon mesh (monotonic lon along x,
+        monotonic lat along y).
+    lon_min, lon_max, lat_min, lat_max : float
+        Bounding box (degrees) to crop to - typically the destination mesh's
+        own bounding box, from ``_get_mesh_bbox()``.
+    output_path : str or Path
+        Path to write the cropped ESMF mesh file to.
+    buffer_deg : float, optional
+        Degrees of margin added around the bbox on each side, so the crop
+        window is a strict superset of whatever downstream masking
+        (``map_overlap``) keeps active - the buffer only widens the array
+        bounds, it doesn't change which points end up unmasked. Default 0.5.
+
+    Returns
+    -------
+    output_path : Path
+    """
+
+    assert isinstance(
+        mesh_path, (str, Path)
+    ), "mesh_path must be a path to an existing file"
+    mesh = xr.open_dataset(mesh_path)
+    nx, ny = get_mesh_dimensions(mesh)
+
+    # Only longitude has a 0/360 wrap ambiguity - latitude must stay unwrapped
+    # (see _get_mesh_bbox).
+    center_lon = normalize_deg(mesh["centerCoords"].data[:, 0]).reshape(ny, nx)
+    center_lat = mesh["centerCoords"].data[:, 1].reshape(ny, nx)
+
+    lon_row = center_lon[0, :]
+    lat_col = center_lat[:, 0]
+    assert np.all(np.diff(lon_row) > 0) or np.all(np.diff(lon_row) < 0), (
+        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
+        "longitude along the x-axis (non-cyclic, non-tripolar meshes only)"
+    )
+    assert np.all(np.diff(lat_col) > 0) or np.all(np.diff(lat_col) < 0), (
+        "crop_esmf_mesh_to_bbox() requires a rectangular mesh with monotonic "
+        "latitude along the y-axis (non-cyclic, non-tripolar meshes only)"
+    )
+
+    lon_lo, lon_hi = lon_min - buffer_deg, lon_max + buffer_deg
+    lat_lo, lat_hi = lat_min - buffer_deg, lat_max + buffer_deg
+
+    i_in_range = np.where((lon_row >= lon_lo) & (lon_row <= lon_hi))[0]
+    j_in_range = np.where((lat_col >= lat_lo) & (lat_col <= lat_hi))[0]
+    assert i_in_range.size > 0 and j_in_range.size > 0, (
+        "crop_esmf_mesh_to_bbox(): no source mesh cells fall within the "
+        "requested bounding box + buffer"
+    )
+    imin, imax = int(i_in_range.min()), int(i_in_range.max()) + 1
+    jmin, jmax = int(j_in_range.min()), int(j_in_range.max()) + 1
+
+    mask_c = mesh["elementMask"].data.reshape(ny, nx)[jmin:jmax, imin:imax]
+    center_lon_c = mesh["centerCoords"].data[:, 0].reshape(ny, nx)[jmin:jmax, imin:imax]
+    center_lat_c = mesh["centerCoords"].data[:, 1].reshape(ny, nx)[jmin:jmax, imin:imax]
+
+    node_lon = mesh["nodeCoords"].data[:, 0].reshape(ny + 1, nx + 1)
+    node_lat = mesh["nodeCoords"].data[:, 1].reshape(ny + 1, nx + 1)
+    node_lon_c = node_lon[jmin : jmax + 1, imin : imax + 1]
+    node_lat_c = node_lat[jmin : jmax + 1, imin : imax + 1]
+
+    ny_c, nx_c = mask_c.shape
+    node_idx = np.arange((ny_c + 1) * (nx_c + 1)).reshape(ny_c + 1, nx_c + 1)
+    element_conn_c = (
+        np.stack(
+            [
+                node_idx[:-1, :-1].ravel(),
+                node_idx[:-1, 1:].ravel(),
+                node_idx[1:, 1:].ravel(),
+                node_idx[1:, :-1].ravel(),
+            ],
+            axis=1,
+        )
+        + 1  # one-based, per ESMF mesh convention
+    ).astype(np.float64)
+
+    lon_units = mesh["centerCoords"].attrs.get("units", "degrees")
+
+    ds_out = xr.Dataset(
+        {
+            "nodeCoords": (
+                ("nodeCount", "coordDim"),
+                np.stack([node_lon_c.ravel(), node_lat_c.ravel()], axis=1),
+                {"units": lon_units},
+            ),
+            "elementConn": (
+                ("elementCount", "maxNodePElement"),
+                element_conn_c,
+                {"long_name": "Node indices that define the element connectivity"},
+            ),
+            "numElementConn": (
+                ("elementCount",),
+                np.full(ny_c * nx_c, 4, dtype=np.int32),
+                {"long_name": "Number of nodes per element"},
+            ),
+            "centerCoords": (
+                ("elementCount", "coordDim"),
+                np.stack([center_lon_c.ravel(), center_lat_c.ravel()], axis=1),
+                {"units": lon_units},
+            ),
+            "elementMask": (
+                ("elementCount",),
+                mask_c.ravel().astype(mesh["elementMask"].dtype),
+                {"units": "unitless"},
+            ),
+        }
+    )
+    ds_out.attrs["gridType"] = "unstructured mesh"
+    ds_out.attrs["history"] = (
+        f"Cropped from {Path(mesh_path).name} to bbox "
+        f"lon=[{lon_min:.3f}, {lon_max:.3f}] lat=[{lat_min:.3f}, {lat_max:.3f}] "
+        f"+ {buffer_deg} deg buffer, by mom6_forge.mapping.crop_esmf_mesh_to_bbox()"
+    )
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ds_out.to_netcdf(output_path)
+    return output_path
+
+
 def generate_ESMF_map_via_xesmf(
     src_mesh_path,
     dst_mesh_path,
@@ -562,23 +734,7 @@ def generate_ESMF_map_via_xesmf(
     # from dst mesh, find the lower left corner and upper right corner
     # then, in the src mesh, zero out the mask falling outside of this rectangle
     if map_overlap:
-        assert isinstance(
-            dst_mesh_path, (str, Path)
-        ), "dst_mesh_path must be a path to an existing file"
-        assert Path(
-            dst_mesh_path
-        ).exists(), "dst_mesh_path must point to an existing ESMF mesh file"
-        dst_mesh = xr.open_dataset(dst_mesh_path)
-        assert (
-            "units" in dst_mesh["centerCoords"].attrs
-        ), "centerCoords must have 'units' attribute"
-        assert (
-            "degrees" in dst_mesh["centerCoords"].attrs["units"]
-        ), "get_mesh_dimensions() expects centerCoords in degrees"
-        dst_mesh_lon = normalize_deg(dst_mesh["nodeCoords"].data[:, 0])
-        dst_mesh_lat = normalize_deg(dst_mesh["nodeCoords"].data[:, 1])
-        lon_min, lon_max = dst_mesh_lon.min(), dst_mesh_lon.max()
-        lat_min, lat_max = dst_mesh_lat.min(), dst_mesh_lat.max()
+        lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(dst_mesh_path)
 
         # normalize source grid coordinates
         src_lon = normalize_deg(src_grid["lon"].data)
@@ -835,7 +991,14 @@ def get_smoothed_map_filepath(mapping_file_prefix, output_dir, rmax, fold):
 
 
 def gen_rof_maps(
-    rof_mesh_path, ocn_mesh_path, output_dir, mapping_file_prefix, rmax=None, fold=None
+    rof_mesh_path,
+    ocn_mesh_path,
+    output_dir,
+    mapping_file_prefix,
+    rmax=None,
+    fold=None,
+    crop_source_mesh=True,
+    crop_buffer_deg=0.5,
 ):
     """Generate (1) nearest neighbor and (2) smoothed nearest neighbor mapping files
     from a runoff mesh to an ocean mesh.
@@ -855,6 +1018,14 @@ def gen_rof_maps(
         Maximum distance for smoothing weights, in kilometers. If None, no smoothing is applied.
     fold : float, optional
         Fold factor (km) determining the strength of smoothing based on distance. If None, no smoothing is applied.
+    crop_source_mesh : bool, optional
+        If True (default), crop the ROF source mesh down to a rectangular window
+        around the ocean mesh's bounding box (see `crop_esmf_mesh_to_bbox`) before
+        generating maps. This is what makes generation tractable for a full-size
+        production ROF mesh; disable only to compare against the uncropped path.
+    crop_buffer_deg : float, optional
+        Buffer (degrees) added around the ocean mesh's bounding box when cropping.
+        Only used if `crop_source_mesh` is True. Default 0.5.
     """
 
     print(f"Generating nearest neighbor mapping file...")
@@ -875,6 +1046,20 @@ def gen_rof_maps(
     assert isinstance(output_dir, (str, Path)), "output_dir must be a string or Path"
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if crop_source_mesh:
+        print(f"Cropping ROF source mesh to ocean mesh bounding box...")
+        lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(ocn_mesh_path)
+        rof_mesh_path = crop_esmf_mesh_to_bbox(
+            rof_mesh_path,
+            lon_min,
+            lon_max,
+            lat_min,
+            lat_max,
+            output_dir / f"{mapping_file_prefix}_rof_mesh_cropped.nc",
+            buffer_deg=crop_buffer_deg,
+        )
+        print(f"  Cropped ROF mesh written to {rof_mesh_path}")
 
     nn_map_filepath = get_nn_map_filepath(mapping_file_prefix, output_dir)
 

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -554,6 +554,52 @@ def write_mapping_file(
         subprocess.run(["nccopy", "-6", str(tmp_nc4), str(filename)], check=True)
 
 
+def _lon_bbox(lon):
+    """Smallest longitude interval in [0, 360) containing every value in `lon`.
+
+    Returns ``(lon_min, lon_max)``. **The interval may wrap**: if it crosses the
+    0/360 seam then ``lon_min > lon_max``, and it covers
+    ``[lon_min, 360) | [0, lon_max]``. Callers must test for that rather than
+    assuming an ordered pair.
+
+    Taking ``min()``/``max()`` of normalized longitudes is what this replaces, and
+    it is wrong for any mesh touching the seam. ``normalize_deg`` is
+    ``mod(x + 360, 360)``, so a node at exactly lon 360 becomes 0 - which then *is*
+    the minimum, while 359.92 is the maximum. A domain spanning 280..360 reports a
+    bbox of 0.00..359.92, i.e. nearly the whole globe. Downstream that turned
+    `generate_ESMF_map_via_xesmf`'s `map_overlap` masking into a no-op in
+    longitude, so the regrid ran against a global latitude band instead of the
+    domain's own window and did not finish in over an hour.
+
+    Find the largest angular *gap* between successive longitudes instead; the
+    domain is everything outside that gap. For a fully periodic (global) mesh every
+    gap equals the grid spacing, so the tie falls through to the unwrapped answer,
+    which is the full range - the behavior a global mesh wants.
+    """
+    lon = np.unique(normalize_deg(np.asarray(lon, dtype=float)))
+    if lon.size == 1:
+        return float(lon[0]), float(lon[0])
+    gaps = np.diff(lon)
+    wrap_gap = lon[0] + 360.0 - lon[-1]
+    widest = int(np.argmax(gaps))
+    if wrap_gap >= gaps[widest]:
+        return float(lon[0]), float(lon[-1])
+    return float(lon[widest + 1]), float(lon[widest])
+
+
+def _lon_outside(lon, lon_min, lon_max):
+    """Boolean mask of longitudes falling outside a possibly-wrapped interval.
+
+    Companion to `_lon_bbox`: when the interval wraps (``lon_min > lon_max``) the
+    "outside" test flips from OR to AND, since outside then means "west of the
+    start *and* east of the end".
+    """
+    lon = normalize_deg(lon)
+    if lon_min <= lon_max:
+        return (lon < lon_min) | (lon > lon_max)
+    return (lon < lon_min) & (lon > lon_max)
+
+
 def _get_mesh_bbox(mesh_path):
     """Compute the lon/lat bounding box (degrees, normalized to [0, 360)) covered
     by an ESMF mesh's nodes.
@@ -566,6 +612,9 @@ def _get_mesh_bbox(mesh_path):
     Returns
     -------
     lon_min, lon_max, lat_min, lat_max : float
+        The longitude interval may wrap the 0/360 seam, in which case
+        ``lon_min > lon_max`` - see `_lon_bbox`. Pair it with `_lon_outside`
+        rather than comparing against it directly.
     """
 
     assert isinstance(
@@ -584,9 +633,9 @@ def _get_mesh_bbox(mesh_path):
     # Only longitude has a 0/360 wrap ambiguity to normalize away - latitude is
     # already well-defined and must not be wrapped (mod 360 would corrupt any
     # negative latitude, e.g. -6.95 -> 353.05).
-    mesh_lon = normalize_deg(mesh["nodeCoords"].data[:, 0])
+    lon_min, lon_max = _lon_bbox(mesh["nodeCoords"].data[:, 0])
     mesh_lat = mesh["nodeCoords"].data[:, 1]
-    return mesh_lon.min(), mesh_lon.max(), mesh_lat.min(), mesh_lat.max()
+    return lon_min, lon_max, mesh_lat.min(), mesh_lat.max()
 
 
 def generate_ESMF_map_via_xesmf(
@@ -624,22 +673,23 @@ def generate_ESMF_map_via_xesmf(
     if map_overlap:
         lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(dst_mesh_path)
 
-        # Normalize longitude only, to match _get_mesh_bbox's [0, 360) convention
-        # for the bbox it just returned. Latitude must NOT be wrapped: mod 360
-        # turns a negative latitude into a large positive one (-5 -> 355), which
-        # then compares as "north of lat_max" and silently masks out source cells
-        # that really do fall inside the destination domain. That made every
-        # runoff source point below the equator invisible - harmless for a
-        # northern-hemisphere domain, but it dropped ~10% of source rivers for an
-        # equator-straddling domain and masked out *all* of them for a purely
-        # southern one, yielding an empty mapping file. Same reasoning as the
-        # latitude handling in _get_mesh_bbox.
-        src_lon = normalize_deg(src_grid["lon"].data)
+        # Longitude goes through _lon_outside, which handles the case where the
+        # destination straddles the 0/360 seam and _get_mesh_bbox therefore
+        # returned a wrapped interval (lon_min > lon_max). A plain
+        # `(lon < lon_min) | (lon > lon_max)` is inverted for such a domain.
+        #
+        # Latitude must NOT be wrapped: mod 360 turns a negative latitude into a
+        # large positive one (-5 -> 355), which then compares as "north of
+        # lat_max" and silently masks out source cells that really do fall inside
+        # the destination domain. That made every runoff source point below the
+        # equator invisible - harmless for a northern-hemisphere domain, but it
+        # dropped ~10% of source rivers for an equator-straddling domain and
+        # masked out *all* of them for a purely southern one, yielding an empty
+        # mapping file. Same reasoning as the latitude handling in _get_mesh_bbox.
         src_lat = src_grid["lat"].data
 
         src_grid["mask"].data = np.where(
-            (src_lon < lon_min)
-            | (src_lon > lon_max)
+            _lon_outside(src_grid["lon"].data, lon_min, lon_max)
             | (src_lat < lat_min)
             | (src_lat > lat_max),
             0,

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -173,22 +173,23 @@ def _construct_vertex_coords(mesh):
         The vertex coordinates in the y-direction.
     """
 
+    xv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
+    yv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
+
     element_conn = mesh.elementConn.data - 1  # one-based to zero-based indexing
     node_coords = mesh.nodeCoords.data
 
-    # Triangular elements store NaN in the 4th connectivity slot (nodes 0-2
-    # are always valid); gather all four slots at once, replacing NaN with a
-    # placeholder index of 0, then overwrite the placeholder for triangles by
-    # duplicating vertex 2 - matching the fan-out a Python loop would do, but
-    # vectorized.
-    is_tri = np.isnan(element_conn[:, 3])
-    conn_safe = np.where(np.isnan(element_conn), 0, element_conn).astype(int)
-
-    xv_data = node_coords[conn_safe, 0]
-    yv_data = node_coords[conn_safe, 1]
-
-    xv_data[is_tri, 3] = xv_data[is_tri, 2]
-    yv_data[is_tri, 3] = yv_data[is_tri, 2]
+    for e, nodes in enumerate(element_conn):
+        if np.isnan(nodes[3]):
+            valid_nodes = nodes[:3][~np.isnan(nodes[:3])].astype(int)
+            xv_data[e, :3] = node_coords[valid_nodes, 0]
+            xv_data[e, 3] = xv_data[e, 2]
+            yv_data[e, :3] = node_coords[valid_nodes, 1]
+            yv_data[e, 3] = yv_data[e, 2]
+        else:
+            valid_nodes = nodes.astype(int)
+            xv_data[e, :] = node_coords[valid_nodes, 0]
+            yv_data[e, :] = node_coords[valid_nodes, 1]
 
     return xv_data, yv_data
 

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -2,12 +2,8 @@
 
 import os
 import argparse
-import shutil
-import subprocess
-import tempfile
 import xarray as xr
 import numpy as np
-import netCDF4
 import datetime
 from time import time
 from pathlib import Path
@@ -198,58 +194,33 @@ def _construct_vertex_coords(mesh):
     return xv_data, yv_data
 
 
-# Only "S", "row", and "col" - one-dimensional over the "n_s" dimension - are
-# actually read back when a mapping file is turned into a route handle: CMEPS
+# Mapping files go out as NETCDF4 with deflate compression. That is a
+# deliberate departure from the NETCDF3_64BIT that CESM mapping files have
+# traditionally used, and it rests on how the file is actually consumed: CMEPS
 # calls ESMF_FieldSMMStore(fldsrc, flddst, mapfile, ...) (med_map_mod.F90),
 # which dispatches to ESMF_FieldSMMStoreFromFile -> ESMF_FactorRead, and
-# ESMF_FactorRead.F90 states plainly that "Only 'row', 'col', and 'S' variables
-# are required". Everything else in the CESM/SCRIP mapping-file layout is
-# descriptive, and on large grids it dwarfs the weights themselves: for a global
-# GLOFAS source mesh (n_a = 21,600,000) the per-source-cell geometry alone is
-# over 2 GB, all of it recoverable from the source mesh file it was derived from.
+# ESMF_FactorRead.F90 reads "row", "col" and "S" through plain nf90_get_var
+# calls with no format check anywhere in the path. libnetcdf resolves the
+# format for it, so a compressed netCDF4 file reads identically.
 #
-# src_grid_dims/dst_grid_dims are kept even in a minimal file because they are
-# two integers each and record the (nx, ny) shape that the flat n_a/n_b indices
-# in col/row refer to - the one piece of context the weights can't carry.
-MINIMAL_MAP_VARIABLES = ("src_grid_dims", "dst_grid_dims", "S", "col", "row")
-
-# Deflate settings for the NETCDF4 record-keeping companion. Level 4 is the
-# knee of the curve on this data - most of what level 9 gets, at a fraction of
-# the write cost - and there is no point chunking arrays smaller than a chunk.
+# Verified in a live CESM run rather than by reading source alone: a full
+# factorial of format (NETCDF3_64BIT_OFFSET / cdf5 / netCDF4 / netCDF4+deflate)
+# x index dtype (int32 / int64) x _FillValue (present / suppressed) was run
+# through the same regional case, and all six variants produced bit-identical
+# mediator history output across 159 fields, including the two mapped runoff
+# fields. Compression is therefore free, and it is worth a great deal: on a
+# global GLOFAS source mesh (n_a = 21,600,000) an Indo-Pacific map at rmax=100
+# goes from 25.85 GiB to 0.72 GiB, a 36x reduction.
+#
+# Level 4 is the knee of the curve on this data - most of what level 9 gets, at
+# a fraction of the write cost - and there is no point chunking arrays smaller
+# than a chunk.
 _DEFLATE_LEVEL = 4
 _DEFLATE_MIN_SIZE = 4096
 
 
-def get_full_map_filepath(map_filepath):
-    """Get the companion "full" (all-variables) path for a given mapping file path.
-
-    Parameters
-    ----------
-    map_filepath : str or Path
-        Path to the primary (minimal) mapping file.
-
-    Returns
-    -------
-    Path
-        Same directory and suffix, with "_full" appended to the stem.
-    """
-    map_filepath = Path(map_filepath)
-    return map_filepath.with_name(f"{map_filepath.stem}_full{map_filepath.suffix}")
-
-
-def _require_nccopy():
-    """nccopy is how anything classic-format gets written here - see
-    `_write_map_netcdf`'s note on the classic writer's I/O behaviour."""
-    if shutil.which("nccopy") is None:
-        raise RuntimeError(
-            "write_mapping_file() requires the 'nccopy' command-line tool "
-            "(part of the netCDF-C distribution) on PATH to write the "
-            "NETCDF3_64BIT mapping file CESM's readers require."
-        )
-
-
-def _write_map_netcdf(ds, filename, single_precision=False, classic=True):
-    """Write a mapping-file dataset out to netCDF.
+def _write_map_netcdf(ds, filename, single_precision=False):
+    """Write a mapping-file dataset out as compressed netCDF4.
 
     Parameters
     ----------
@@ -261,21 +232,18 @@ def _write_map_netcdf(ds, filename, single_precision=False, classic=True):
         If True, write every 64-bit float variable as 32-bit, halving the size of
         the dominant variables. netCDF converts on read, and ESMF_FactorRead
         reads S into a real(ESMF_KIND_R8) buffer regardless of the on-disk type,
-        so a single-precision file is still a valid ESMF weight file.
-    classic : bool, optional
-        If True (the default), write NETCDF3_64BIT, which is what CESM's
-        mapping-file readers require. If False, write NETCDF4 with deflate
-        compression - appropriate for a file that is never handed to CESM, and
-        the only option once a variable exceeds what classic format can address.
+        so a single-precision file is still a valid ESMF weight file. It is also
+        where most of the compression comes from: rounding to float32 collapses
+        the number of distinct weight values by roughly 19x, which is what lets
+        deflate dedupe S from 4.4x down to 21.6x.
     """
 
     filename = Path(filename)
 
-    # NETCDF4/HDF5 supports int64, but the classic 64-bit-offset format does
-    # not - downcast explicitly here since writing NETCDF4 (unlike writing
-    # classic directly through xarray) doesn't do this coercion automatically,
-    # and nccopy errors on int64. Kept for the NETCDF4 path too: nothing here
-    # needs 64-bit indices, and int32 halves the two largest integer arrays.
+    # Nothing here needs 64-bit indices, and int32 halves the two largest
+    # integer arrays (row and col are both length n_s). _FillValue is suppressed
+    # because these are dense arrays with no missing entries - a fill attribute
+    # on them is noise that some readers would otherwise turn into NaNs.
     encoding = {}
     for var in ds.variables:
         enc = {"_FillValue": None}
@@ -288,69 +256,17 @@ def _write_map_netcdf(ds, filename, single_precision=False, classic=True):
             and dtype != np.float32
         ):
             enc["dtype"] = "float32"
-        if not classic:
-            # Only worth it on the arrays that dominate; the grid-dims and
-            # ni/nj index arrays are too small for chunking overhead to pay off.
-            # mask/frac are near-constant and compress by well over an order of
-            # magnitude; the coordinate and weight arrays are smooth enough to
-            # give back a useful fraction too.
-            if ds[var].size >= _DEFLATE_MIN_SIZE:
-                enc["zlib"] = True
-                enc["complevel"] = _DEFLATE_LEVEL
+        # Only worth it on the arrays that dominate; the grid-dims and ni/nj
+        # index arrays are too small for chunking overhead to pay off. mask/frac
+        # are near-constant and compress by well over an order of magnitude; the
+        # coordinate and weight arrays are smooth enough to give back a useful
+        # fraction too.
+        if ds[var].size >= _DEFLATE_MIN_SIZE:
+            enc["zlib"] = True
+            enc["complevel"] = _DEFLATE_LEVEL
         encoding[var] = enc
 
-    if not classic:
-        ds.to_netcdf(filename, format="NETCDF4", encoding=encoding)
-        return
-
-    # NETCDF3_64BIT is required for compatibility with CESM's mapping-file
-    # readers, but writing large fixed-size variables directly in that format
-    # via netCDF4-python/xarray triggers pathological backward-seeking,
-    # read-before-write I/O in the classic-format writer (~17x slower on a
-    # 21.6M-element mesh - confirmed both through xarray and the low-level
-    # netCDF4 API). Writing NETCDF4 (HDF5) first and converting with `nccopy`
-    # avoids that writer entirely and is dramatically faster.
-    _require_nccopy()
-    with tempfile.TemporaryDirectory(dir=filename.parent) as tmpdir:
-        tmp_nc4 = Path(tmpdir) / "tmp_netcdf4.nc"
-        ds.to_netcdf(tmp_nc4, format="NETCDF4", encoding=encoding)
-        subprocess.run(["nccopy", "-6", str(tmp_nc4), str(filename)], check=True)
-
-
-def _extract_classic_subset(src_path, dst_path, variables):
-    """Copy just `variables` out of a netCDF file into a NETCDF3_64BIT file.
-
-    `nccopy -V` takes definitions and data for the listed variables only, and
-    drops every dimension no listed variable uses - so the n_a/n_b geometry
-    dimensions disappear without being named here. Global attributes come
-    across unchanged.
-    """
-    _require_nccopy()
-    subprocess.run(
-        ["nccopy", "-6", "-V", ",".join(variables), str(src_path), str(dst_path)],
-        check=True,
-    )
-
-
-def _set_full_map_attrs(full_path, minimal_name):
-    """Stamp the record-keeping companion's own description into its header.
-
-    Done as an in-place header edit after the file is written, rather than
-    before: the companion shares `ds` with the classic file carved out of it, and
-    HDF5 rewrites an attribute without touching the data section.
-    """
-    with netCDF4.Dataset(full_path, "a") as nc:
-        nc.setncattr(
-            "contents",
-            "all mapping-file variables (record-keeping companion to "
-            f"{minimal_name})",
-        )
-        nc.setncattr(
-            "format_note",
-            "NETCDF4/deflate - this file is not read by CESM, so it is not held "
-            "to the NETCDF3_64BIT format its mapping-file readers require, nor "
-            "to that format's 4 GiB per-variable ceiling.",
-        )
+    ds.to_netcdf(filename, format="NETCDF4", encoding=encoding)
 
 
 def write_mapping_file(
@@ -361,8 +277,6 @@ def write_mapping_file(
     weights_esmpy=None,
     weights_coo=None,
     area_normalization=False,
-    minimal=False,
-    full_map_filename=None,
     single_precision=False,
 ):
     """Based on a given source mesh, destination mesh, and weights, write out an ESMF map file.
@@ -385,18 +299,9 @@ def write_mapping_file(
         Regridding method, by default 'bilinear'.
     area_normalization : bool, optional
         Whether to multiply the weights by (area_source / area_destination), by default False.
-    minimal : bool, optional
-        If True, `filename` contains only the variables an ESMF/CESM route handle
-        actually needs (see `MINIMAL_MAP_VARIABLES`), omitting the per-cell source
-        and destination geometry. By default False (write every variable).
-    full_map_filename : str or Path, optional
-        If given, additionally write the complete, all-variables mapping file
-        here, for record keeping, as compressed NETCDF4 rather than the
-        NETCDF3_64BIT `filename` gets. Only meaningful alongside `minimal=True`;
-        passing it with `minimal=False` would just duplicate `filename`.
     single_precision : bool, optional
         If True, write 64-bit float variables as 32-bit, halving their on-disk
-        size. Applies to both `filename` and `full_map_filename`.
+        size.
 
     Returns
     -------
@@ -405,12 +310,6 @@ def write_mapping_file(
 
     if rank() != 0:
         return  # TODO: parallelize this function
-
-    if full_map_filename is not None and not minimal:
-        raise ValueError(
-            "full_map_filename is only meaningful with minimal=True; with "
-            "minimal=False it would be an exact duplicate of filename."
-        )
 
     if isinstance(src_mesh, (str, Path)):
         src_mesh = xr.open_dataset(src_mesh)
@@ -441,13 +340,11 @@ def write_mapping_file(
             weights_coo, coo_matrix
         ), "weights_coo must be a scipy sparse COO matrix"
 
-    # The descriptive geometry is only assembled if some output file will carry
-    # it; the cell areas are needed either way when area_normalization is on.
-    # Skipping it keeps the (n_a, 4) vertex-coordinate reconstruction - by far
-    # the largest intermediate here on a global source mesh - out of memory
-    # entirely for a minimal-only write.
-    write_geometry = (not minimal) or (full_map_filename is not None)
-    need_areas = write_geometry or area_normalization
+    # Every mapping file carries the full CESM/SCRIP variable set. Dropping the
+    # per-source-cell geometry was measured to save only ~1.3% of the file once
+    # deflate is applied - mask/frac and the coordinate arrays compress away
+    # almost entirely - which is not worth shipping a file that no longer
+    # describes its own grids.
 
     # Only the (ny, nx) shape of each mesh is needed below - get it directly
     # from element connectivity, without reconstructing full mesh geometry.
@@ -459,69 +356,67 @@ def write_mapping_file(
     # 1/3: Source Domain Fields
     # -------------------
 
-    if need_areas:
-        xv_a_data, yv_a_data = _construct_vertex_coords(src_mesh)
-        area_a_data = cell_area_rad(xv_a_data, yv_a_data)
+    xv_a_data, yv_a_data = _construct_vertex_coords(src_mesh)
+    area_a_data = cell_area_rad(xv_a_data, yv_a_data)
 
-    if write_geometry:
-        ds_vars["xc_a"] = xr.DataArray(
-            src_mesh.centerCoords.data[:, 0],
-            dims=["n_a"],
-            attrs={
-                "long_name": "longitude of grid cell center (input)",
-                "units": "degrees east",
-            },
-        )
+    ds_vars["xc_a"] = xr.DataArray(
+        src_mesh.centerCoords.data[:, 0],
+        dims=["n_a"],
+        attrs={
+            "long_name": "longitude of grid cell center (input)",
+            "units": "degrees east",
+        },
+    )
 
-        ds_vars["yc_a"] = xr.DataArray(
-            src_mesh.centerCoords.data[:, 1],
-            dims=["n_a"],
-            attrs={
-                "long_name": "latitude of grid cell center (input)",
-                "units": "degrees north",
-            },
-        )
+    ds_vars["yc_a"] = xr.DataArray(
+        src_mesh.centerCoords.data[:, 1],
+        dims=["n_a"],
+        attrs={
+            "long_name": "latitude of grid cell center (input)",
+            "units": "degrees north",
+        },
+    )
 
-        ds_vars["xv_a"] = xr.DataArray(
-            xv_a_data,
-            dims=["n_a", "nv_a"],
-            attrs={
-                "long_name": "longitude of grid cell verticies (input)",
-                "units": "degrees east",
-            },
-        )
+    ds_vars["xv_a"] = xr.DataArray(
+        xv_a_data,
+        dims=["n_a", "nv_a"],
+        attrs={
+            "long_name": "longitude of grid cell verticies (input)",
+            "units": "degrees east",
+        },
+    )
 
-        ds_vars["yv_a"] = xr.DataArray(
-            yv_a_data,
-            dims=["n_a", "nv_a"],
-            attrs={
-                "long_name": "latitude of grid cell verticies (input)",
-                "units": "degrees north",
-            },
-        )
+    ds_vars["yv_a"] = xr.DataArray(
+        yv_a_data,
+        dims=["n_a", "nv_a"],
+        attrs={
+            "long_name": "latitude of grid cell verticies (input)",
+            "units": "degrees north",
+        },
+    )
 
-        ds_vars["mask_a"] = xr.DataArray(
-            src_mesh.elementMask.data,
-            dims=["n_a"],
-            attrs={
-                "long_name": "domain mask (input)",
-            },
-        )
+    ds_vars["mask_a"] = xr.DataArray(
+        src_mesh.elementMask.data,
+        dims=["n_a"],
+        attrs={
+            "long_name": "domain mask (input)",
+        },
+    )
 
-        ds_vars["area_a"] = xr.DataArray(
-            area_a_data,
-            dims=["n_a"],
-            attrs={"long_name": "area of cell (input)", "units": "radians^2"},
-        )
+    ds_vars["area_a"] = xr.DataArray(
+        area_a_data,
+        dims=["n_a"],
+        attrs={"long_name": "area of cell (input)", "units": "radians^2"},
+    )
 
-        ds_vars["frac_a"] = xr.DataArray(
-            src_mesh.elementMask.data.astype(np.float64),
-            dims=["n_a"],
-            attrs={
-                "long_name": "fraction of domain intersection (input)",
-                #'units': ''
-            },
-        )
+    ds_vars["frac_a"] = xr.DataArray(
+        src_mesh.elementMask.data.astype(np.float64),
+        dims=["n_a"],
+        attrs={
+            "long_name": "fraction of domain intersection (input)",
+            #'units': ''
+        },
+    )
 
     ds_vars["src_grid_dims"] = xr.DataArray(
         np.array([src_nx, src_ny]).astype(np.int32),
@@ -531,83 +426,80 @@ def write_mapping_file(
         # }
     )
 
-    if write_geometry:
-        ds_vars["nj_a"] = xr.DataArray(
-            [i + 1 for i in range(src_ny)],
-            dims=["nj_a"],
-        )
+    ds_vars["nj_a"] = xr.DataArray(
+        [i + 1 for i in range(src_ny)],
+        dims=["nj_a"],
+    )
 
-        ds_vars["ni_a"] = xr.DataArray(
-            [i + 1 for i in range(src_nx)],
-            dims=["ni_a"],
-        )
+    ds_vars["ni_a"] = xr.DataArray(
+        [i + 1 for i in range(src_nx)],
+        dims=["ni_a"],
+    )
 
     # 2/3: Destination Domain Fields
     # -------------------
 
-    if need_areas:
-        xv_b_data, yv_b_data = _construct_vertex_coords(dst_mesh)
-        area_b_data = cell_area_rad(xv_b_data, yv_b_data)
+    xv_b_data, yv_b_data = _construct_vertex_coords(dst_mesh)
+    area_b_data = cell_area_rad(xv_b_data, yv_b_data)
 
-    if write_geometry:
-        ds_vars["xc_b"] = xr.DataArray(
-            dst_mesh.centerCoords.data[:, 0],
-            dims=["n_b"],
-            attrs={
-                "long_name": "longitude of grid cell center (output)",
-                "units": "degrees east",
-            },
-        )
+    ds_vars["xc_b"] = xr.DataArray(
+        dst_mesh.centerCoords.data[:, 0],
+        dims=["n_b"],
+        attrs={
+            "long_name": "longitude of grid cell center (output)",
+            "units": "degrees east",
+        },
+    )
 
-        ds_vars["yc_b"] = xr.DataArray(
-            dst_mesh.centerCoords.data[:, 1],
-            dims=["n_b"],
-            attrs={
-                "long_name": "latitude of grid cell center (output)",
-                "units": "degrees north",
-            },
-        )
+    ds_vars["yc_b"] = xr.DataArray(
+        dst_mesh.centerCoords.data[:, 1],
+        dims=["n_b"],
+        attrs={
+            "long_name": "latitude of grid cell center (output)",
+            "units": "degrees north",
+        },
+    )
 
-        ds_vars["xv_b"] = xr.DataArray(
-            xv_b_data,
-            dims=["n_b", "nv_b"],
-            attrs={
-                "long_name": "longitude of grid cell verticies (output)",
-                "units": "degrees east",
-            },
-        )
+    ds_vars["xv_b"] = xr.DataArray(
+        xv_b_data,
+        dims=["n_b", "nv_b"],
+        attrs={
+            "long_name": "longitude of grid cell verticies (output)",
+            "units": "degrees east",
+        },
+    )
 
-        ds_vars["yv_b"] = xr.DataArray(
-            yv_b_data,
-            dims=["n_b", "nv_b"],
-            attrs={
-                "long_name": "latitude of grid cell verticies (output)",
-                "units": "degrees north",
-            },
-        )
+    ds_vars["yv_b"] = xr.DataArray(
+        yv_b_data,
+        dims=["n_b", "nv_b"],
+        attrs={
+            "long_name": "latitude of grid cell verticies (output)",
+            "units": "degrees north",
+        },
+    )
 
-        ds_vars["mask_b"] = xr.DataArray(
-            dst_mesh.elementMask.data,
-            dims=["n_b"],
-            attrs={
-                "long_name": "domain mask (output)",
-            },
-        )
+    ds_vars["mask_b"] = xr.DataArray(
+        dst_mesh.elementMask.data,
+        dims=["n_b"],
+        attrs={
+            "long_name": "domain mask (output)",
+        },
+    )
 
-        ds_vars["area_b"] = xr.DataArray(
-            area_b_data,
-            dims=["n_b"],
-            attrs={"long_name": "area of cell (output)", "units": "radians^2"},
-        )
+    ds_vars["area_b"] = xr.DataArray(
+        area_b_data,
+        dims=["n_b"],
+        attrs={"long_name": "area of cell (output)", "units": "radians^2"},
+    )
 
-        ds_vars["frac_b"] = xr.DataArray(
-            dst_mesh.elementMask.data.astype(np.float64),
-            dims=["n_b"],
-            attrs={
-                "long_name": "fraction of domain intersection (output)",
-                #'units': ''
-            },
-        )
+    ds_vars["frac_b"] = xr.DataArray(
+        dst_mesh.elementMask.data.astype(np.float64),
+        dims=["n_b"],
+        attrs={
+            "long_name": "fraction of domain intersection (output)",
+            #'units': ''
+        },
+    )
 
     ds_vars["dst_grid_dims"] = xr.DataArray(
         np.array([dst_nx, dst_ny]).astype(np.int32),
@@ -617,16 +509,15 @@ def write_mapping_file(
         # }
     )
 
-    if write_geometry:
-        ds_vars["nj_b"] = xr.DataArray(
-            [i + 1 for i in range(dst_ny)],
-            dims=["nj_b"],
-        )
+    ds_vars["nj_b"] = xr.DataArray(
+        [i + 1 for i in range(dst_ny)],
+        dims=["nj_b"],
+    )
 
-        ds_vars["ni_b"] = xr.DataArray(
-            [i + 1 for i in range(dst_nx)],
-            dims=["ni_b"],
-        )
+    ds_vars["ni_b"] = xr.DataArray(
+        [i + 1 for i in range(dst_nx)],
+        dims=["ni_b"],
+    )
 
     # 3/3: Weights
     # -------------------
@@ -692,40 +583,6 @@ def write_mapping_file(
         ds.attrs["domain_a"] = src_mesh_path
     if dst_mesh_path := dst_mesh.encoding.get("source"):
         ds.attrs["domain_b"] = dst_mesh_path
-
-    if minimal:
-        ds.attrs["contents"] = (
-            "minimal mapping file: only the variables ESMF reads to build a "
-            "route handle (S, row, col + grid dims). Per-cell source and "
-            "destination geometry is omitted - see domain_a/domain_b."
-        )
-
-    if full_map_filename is not None:
-        # Write the all-variables file first, as compressed NETCDF4, then carve
-        # the CESM-facing file out of it with `nccopy -6 -V`. Writing the two
-        # independently would serialize the weight arrays to disk three times
-        # (compressed companion, uncompressed classic-conversion temp, final
-        # classic file); this way they are written once compressed and once in
-        # final form, and the subsetting is a streaming C-level copy.
-        #
-        # The companion is NETCDF4 rather than classic because nothing hands it
-        # to CESM: compression is free there, and classic format cannot address
-        # a single variable over 4 GiB at all (S alone is 11.8 GiB for
-        # CrocIndoPacific_112 at rmax=100).
-        #
-        # `ds` still carries the *minimal* file's global attributes at this
-        # point, deliberately: nccopy copies them straight through to the file
-        # it produces, and the companion's own description is applied afterwards
-        # by editing its header in place - cheap in HDF5, whereas growing a
-        # global attribute in an already-written classic file can force the
-        # whole data section to shift.
-        _write_map_netcdf(ds, full_map_filename, single_precision, classic=False)
-        _extract_classic_subset(full_map_filename, filename, MINIMAL_MAP_VARIABLES)
-        _set_full_map_attrs(full_map_filename, Path(filename).name)
-        return
-
-    if minimal:
-        ds = ds[list(MINIMAL_MAP_VARIABLES)]
 
     _write_map_netcdf(ds, filename, single_precision)
 
@@ -821,8 +678,6 @@ def generate_ESMF_map_via_xesmf(
     method,
     area_normalization=False,
     map_overlap=True,
-    minimal=False,
-    full_map_filename=None,
     single_precision=False,
 ):
     """Generate an ESMF mapping file using xesmf.
@@ -842,10 +697,6 @@ def generate_ESMF_map_via_xesmf(
     map_overlap : bool
         If True, only map the overlapping area between the source and destination meshes, i.e.,
         zero out the mask in the source mesh that falls outside the rectangle defined by the destination mesh.
-    minimal : bool, optional
-        Write only the variables ESMF needs to `mapping_file`. See `write_mapping_file`.
-    full_map_filename : str or Path, optional
-        Additionally write the all-variables mapping file here. See `write_mapping_file`.
     single_precision : bool, optional
         Write 64-bit float variables as 32-bit. See `write_mapping_file`.
     """
@@ -905,8 +756,6 @@ def generate_ESMF_map_via_xesmf(
         weights=regridder.weights,
         filename=mapping_file,
         area_normalization=area_normalization,
-        minimal=minimal,
-        full_map_filename=full_map_filename,
         single_precision=single_precision,
     )
 
@@ -1132,8 +981,6 @@ def gen_rof_maps(
     mapping_file_prefix,
     rmax=None,
     fold=None,
-    minimal=True,
-    save_full_map=True,
     single_precision=True,
 ):
     """Generate (1) nearest neighbor and (2) smoothed nearest neighbor mapping files
@@ -1154,24 +1001,12 @@ def gen_rof_maps(
         Maximum distance for smoothing weights, in kilometers. If None, no smoothing is applied.
     fold : float, optional
         Fold factor (km) determining the strength of smoothing based on distance. If None, no smoothing is applied.
-    minimal : bool, optional
-        If True (the default), the mapping files CESM reads carry only the
-        variables ESMF needs - S, row, col and the two grid-dims arrays - which on
-        a global runoff source mesh removes gigabytes of per-source-cell geometry
-        that is fully recoverable from the mesh files themselves.
-    save_full_map : bool, optional
-        If True (the default), also write the complete all-variables version of
-        each mapping file alongside it, named `<name>_full.nc`, for record
-        keeping. That companion goes out as compressed NETCDF4 rather than the
-        NETCDF3_64BIT the CESM-facing file has to be: nothing reads it from
-        CESM, so it is neither bound by that format nor by its 4 GiB
-        per-variable ceiling. Ignored when `minimal` is False.
     single_precision : bool, optional
         If True (the default), write 64-bit float variables as 32-bit, halving
         their on-disk size. netCDF converts on read and ESMF_FactorRead reads S
         into a real(R8) buffer regardless of the on-disk type, so this stays a
-        valid ESMF weight file - and it doubles the headroom before S hits the
-        4 GiB per-variable ceiling of the NETCDF3_64BIT format CESM requires.
+        valid ESMF weight file. It is also what makes the deflate pass effective
+        - see the note above `_write_map_netcdf`.
     """
 
     print(f"Generating nearest neighbor mapping file...")
@@ -1194,7 +1029,6 @@ def gen_rof_maps(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     nn_map_filepath = get_nn_map_filepath(mapping_file_prefix, output_dir)
-    write_full = minimal and save_full_map
 
     generate_ESMF_map_via_xesmf(
         src_mesh_path=rof_mesh_path,
@@ -1202,10 +1036,6 @@ def gen_rof_maps(
         mapping_file=nn_map_filepath,
         method="nearest_d2s",
         area_normalization=True,
-        minimal=minimal,
-        full_map_filename=(
-            get_full_map_filepath(nn_map_filepath) if write_full else None
-        ),
         single_precision=single_precision,
     )
 
@@ -1240,7 +1070,7 @@ def gen_rof_maps(
         )
 
         # mesh dimensions - read from the meshes rather than from the nn map's
-        # ni_a/nj_a/ni_b/nj_b, which a minimal mapping file doesn't carry.
+        # ni_a/nj_a/ni_b/nj_b, to keep this independent of the map's variable set.
         rof_nx, rof_ny = get_mesh_dimensions(rof_mesh_path)
         ocn_nx, ocn_ny = get_mesh_dimensions(ocn_mesh_path)
 
@@ -1267,10 +1097,6 @@ def gen_rof_maps(
             filename=nnsm_map_filepath,
             weights_coo=S_smooth,
             area_normalization=False,  # No area normalization for smoothing
-            minimal=minimal,
-            full_map_filename=(
-                get_full_map_filepath(nnsm_map_filepath) if write_full else None
-            ),
             single_precision=single_precision,
         )
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -5,6 +5,7 @@ import scipy.sparse as sp
 import pytest
 from pathlib import Path
 from mom6_forge.mapping import (
+    MINIMAL_MAP_VARIABLES,
     compute_cressman_weights,
     dst_to_source,
     source_to_dst,
@@ -14,6 +15,7 @@ from mom6_forge.mapping import (
     _get_mesh_bbox,
     write_mapping_file,
     gen_rof_maps,
+    get_full_map_filepath,
     get_nn_map_filepath,
     get_smoothed_map_filepath,
 )
@@ -555,11 +557,208 @@ def test_gen_rof_maps_end_to_end(tmp_path):
     out_dir = tmp_path / "out"
     gen_rof_maps(rof_path, ocn_path, out_dir, "test_map", rmax=50, fold=100)
 
-    ds_nn = xr.open_dataset(get_nn_map_filepath("test_map", out_dir))
-    ds_sm = xr.open_dataset(get_smoothed_map_filepath("test_map", out_dir, 50, 100))
-    assert ds_nn.sizes["n_a"] == ds_sm.sizes["n_a"] == 100  # rof_grid is 10x10
+    nn_path = get_nn_map_filepath("test_map", out_dir)
+    sm_path = get_smoothed_map_filepath("test_map", out_dir, 50, 100)
+    ds_nn = xr.open_dataset(nn_path)
+    ds_sm = xr.open_dataset(sm_path)
     assert ds_nn["S"].size > 0, "expected at least one nonzero nn mapping entry"
     assert ds_sm["S"].size > 0, "expected at least one nonzero smoothed mapping entry"
+    # gen_rof_maps writes minimal files by default, so the per-source-cell
+    # geometry (and its n_a dimension) lives in the _full companions instead.
+    for ds in (ds_nn, ds_sm):
+        assert "n_a" not in ds.sizes
+    with xr.open_dataset(get_full_map_filepath(nn_path)) as ds_nn_full:
+        with xr.open_dataset(get_full_map_filepath(sm_path)) as ds_sm_full:
+            # rof_grid is 10x10
+            assert ds_nn_full.sizes["n_a"] == ds_sm_full.sizes["n_a"] == 100
+
+
+def test_gen_rof_maps_minimal_and_full_agree(tmp_path):
+    """With save_full_map=True the output pair must be self-consistent: the file
+    CESM reads carries exactly the variables ESMF's ESMF_FactorRead() needs, the
+    _full companion carries the whole CESM/SCRIP variable set, and the weights in
+    the two are identical. Also pins the requested-vs-legacy variable sets, so
+    dropping a variable ESMF does read can't pass silently."""
+    rof_grid = Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof_min"
+    )
+    ocn_grid = Grid(
+        resolution=1.0, xstart=13.0, lenx=3.0, ystart=28.0, leny=3.0, name="ocn_min"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof.nc")
+    ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / "ocn.nc")
+
+    out_dir = tmp_path / "out"
+    gen_rof_maps(rof_path, ocn_path, out_dir, "m", rmax=50, fold=100)
+
+    for path in (
+        get_nn_map_filepath("m", out_dir),
+        get_smoothed_map_filepath("m", out_dir, 50, 100),
+    ):
+        full_path = get_full_map_filepath(path)
+        assert full_path.exists(), f"missing record-keeping companion {full_path}"
+        with xr.open_dataset(path) as ds, xr.open_dataset(full_path) as ds_full:
+            assert set(ds.variables) == set(MINIMAL_MAP_VARIABLES)
+            # "row", "col" and "S" over dimension "n_s" are what ESMF_FactorRead
+            # requires; the grid-dims arrays are two ints each and record the
+            # shape that row/col index into.
+            assert {"S", "row", "col"}.issubset(ds.variables)
+            assert ds["S"].dims == ("n_s",)
+            assert set(ds_full.variables) > set(MINIMAL_MAP_VARIABLES)
+            for var in MINIMAL_MAP_VARIABLES:
+                assert np.array_equal(ds[var].values, ds_full[var].values), var
+            # minimal must be strictly smaller - that's the entire point
+            assert path.stat().st_size < full_path.stat().st_size
+
+
+def test_gen_rof_maps_full_companion_is_compressed_netcdf4(tmp_path):
+    """The CESM-facing file must stay NETCDF3_64BIT; the record-keeping companion
+    must not be held to it. Classic format cannot address a variable over 4 GiB -
+    S alone is 11.8 GiB for CrocIndoPacific_112 at rmax=100 - and nothing reads
+    the companion from CESM, so it goes out as compressed NETCDF4 instead."""
+    rof_grid = Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof_fmt"
+    )
+    ocn_grid = Grid(
+        resolution=1.0, xstart=13.0, lenx=3.0, ystart=28.0, leny=3.0, name="ocn_fmt"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof.nc")
+    ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / "ocn.nc")
+
+    out_dir = tmp_path / "out"
+    gen_rof_maps(rof_path, ocn_path, out_dir, "m", rmax=50, fold=100)
+
+    for path in (
+        get_nn_map_filepath("m", out_dir),
+        get_smoothed_map_filepath("m", out_dir, 50, 100),
+    ):
+        nc = netCDF4.Dataset(path)
+        try:
+            assert nc.data_model == "NETCDF3_64BIT_OFFSET", path.name
+        finally:
+            nc.close()
+
+        full_path = get_full_map_filepath(path)
+        nc = netCDF4.Dataset(full_path)
+        try:
+            assert nc.data_model == "NETCDF4", full_path.name
+            # integers stay int32 on this path too - nothing here needs 64-bit
+            for name, var in nc.variables.items():
+                if np.issubdtype(var.dtype, np.integer):
+                    assert var.dtype == np.int32, f"{name} is {var.dtype}"
+        finally:
+            nc.close()
+
+
+def test_write_mapping_file_deflates_large_vars_only(tmp_path):
+    """Deflate is applied to the arrays big enough for it to pay off, and skipped
+    on the handful of tiny index/grid-dims arrays where chunking is pure
+    overhead."""
+    src_grid = Grid(
+        resolution=0.5, xstart=0.0, lenx=40.0, ystart=0.0, leny=40.0, name="src_defl"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_defl"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+    weights_coo = sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6400))
+
+    write_mapping_file(
+        src_mesh=str(src_path),
+        dst_mesh=str(dst_path),
+        filename=tmp_path / "out.nc",
+        weights_coo=weights_coo,
+        minimal=True,
+        full_map_filename=tmp_path / "out_full.nc",
+    )
+
+    nc = netCDF4.Dataset(tmp_path / "out_full.nc")
+    try:
+        # src side is 80x80 = 6400 elements, over the deflate threshold
+        assert nc.variables["xc_a"].filters()["zlib"] is True
+        assert nc.variables["mask_a"].filters()["zlib"] is True
+        # dst side is 2x2 and the grid-dims arrays are length 2 - far below it
+        assert nc.variables["dst_grid_dims"].filters()["zlib"] is False
+        assert nc.variables["xc_b"].filters()["zlib"] is False
+    finally:
+        nc.close()
+
+
+def test_gen_rof_maps_single_precision(tmp_path):
+    """single_precision=True must halve the float variables' on-disk width without
+    changing the integer indices, in both output files, and must survive the
+    nccopy -6 conversion (a float32 S is still a valid ESMF weight file:
+    ESMF_FactorRead reads it into a real(R8) buffer and netCDF converts on
+    read)."""
+    rof_grid = Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof_sp"
+    )
+    ocn_grid = Grid(
+        resolution=1.0, xstart=13.0, lenx=3.0, ystart=28.0, leny=3.0, name="ocn_sp"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof.nc")
+    ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / "ocn.nc")
+
+    dtypes = {}
+    for tag, single in (("f8", False), ("f4", True)):
+        out_dir = tmp_path / tag
+        gen_rof_maps(
+            rof_path,
+            ocn_path,
+            out_dir,
+            "m",
+            rmax=50,
+            fold=100,
+            single_precision=single,
+        )
+        # read the _full companion: it is the one that carries every float
+        # variable, so it exercises the downcast on more than just S
+        nc = netCDF4.Dataset(get_full_map_filepath(get_nn_map_filepath("m", out_dir)))
+        try:
+            dtypes[tag] = {n: v.dtype for n, v in nc.variables.items()}
+        finally:
+            nc.close()
+        # and the CESM-facing file, which must survive the nccopy -6 conversion
+        nc = netCDF4.Dataset(get_nn_map_filepath("m", out_dir))
+        try:
+            assert nc.data_model == "NETCDF3_64BIT_OFFSET"
+            expected = np.float32 if single else np.float64
+            assert nc.variables["S"].dtype == expected
+        finally:
+            nc.close()
+
+    assert dtypes["f8"].keys() == dtypes["f4"].keys()
+    floats = [n for n, d in dtypes["f8"].items() if np.issubdtype(d, np.floating)]
+    assert floats, "expected some float variables to downcast"
+    for name, dtype in dtypes["f4"].items():
+        if name in floats:
+            assert dtype == np.float32, f"{name} is {dtype}, expected float32"
+        else:
+            assert dtype == dtypes["f8"][name] == np.int32, name
+
+
+def test_write_mapping_file_rejects_full_without_minimal(tmp_path):
+    """A full_map_filename alongside minimal=False would be a byte-for-byte
+    duplicate of filename, so it's an error rather than a silent waste of disk."""
+    src_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_dup"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_dup"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+    weights_coo = sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6))
+
+    with pytest.raises(ValueError, match="only meaningful with minimal=True"):
+        write_mapping_file(
+            src_mesh=str(src_path),
+            dst_mesh=str(dst_path),
+            filename=tmp_path / "out.nc",
+            weights_coo=weights_coo,
+            full_map_filename=tmp_path / "out_full.nc",
+        )
 
 
 def test_regrid_with_subsampling_time_dim(get_simple_grid):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -5,7 +5,6 @@ import scipy.sparse as sp
 import pytest
 from pathlib import Path
 from mom6_forge.mapping import (
-    MINIMAL_MAP_VARIABLES,
     compute_cressman_weights,
     dst_to_source,
     source_to_dst,
@@ -15,7 +14,6 @@ from mom6_forge.mapping import (
     _get_mesh_bbox,
     write_mapping_file,
     gen_rof_maps,
-    get_full_map_filepath,
     get_nn_map_filepath,
     get_smoothed_map_filepath,
 )
@@ -500,17 +498,13 @@ def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
     assert list(ds["dst_grid_dims"].values) == [2, 2]
 
 
-def test_write_mapping_file_produces_valid_classic_format(tmp_path):
-    """write_mapping_file writes via an intermediate NETCDF4 file converted with
-    `nccopy -6` (much faster than writing NETCDF3_64BIT directly - see NOTES.md
-    Step 9), but the output must still be a genuine 64-bit-offset classic file,
-    since that's what CESM's mapping-file readers require. Also guards the
-    int64-vs-classic-format bug found while implementing this: `nj_a`/`ni_a`/
-    `nj_b`/`ni_b` are coordinate variables (their DataArray name matches their
-    sole dimension), so an encoding loop scoped to `ds.data_vars` silently skips
-    them and leaves them as int64 - a dtype classic format can't represent at
-    all, which makes `nccopy` fail outright. Every integer variable, coordinate
-    or not, must come out as int32."""
+def test_write_mapping_file_downcasts_every_integer(tmp_path):
+    """Every integer variable comes out as int32, coordinate or not. `nj_a`/
+    `ni_a`/`nj_b`/`ni_b` are coordinate variables (their DataArray name matches
+    their sole dimension), so an encoding loop scoped to `ds.data_vars` silently
+    skips them and leaves them as int64 - which is how this was found. Nothing in
+    a mapping file needs 64-bit indices, and int32 halves `row` and `col`, the
+    two largest integer arrays."""
     src_grid = Grid(
         resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_classic"
     )
@@ -531,7 +525,7 @@ def test_write_mapping_file_produces_valid_classic_format(tmp_path):
 
     nc = netCDF4.Dataset(out_path)
     try:
-        assert nc.data_model == "NETCDF3_64BIT_OFFSET"
+        assert nc.data_model == "NETCDF4"
         for name, var in nc.variables.items():
             if np.issubdtype(var.dtype, np.integer):
                 assert var.dtype == np.int32, f"{name} is {var.dtype}, expected int32"
@@ -563,22 +557,14 @@ def test_gen_rof_maps_end_to_end(tmp_path):
     ds_sm = xr.open_dataset(sm_path)
     assert ds_nn["S"].size > 0, "expected at least one nonzero nn mapping entry"
     assert ds_sm["S"].size > 0, "expected at least one nonzero smoothed mapping entry"
-    # gen_rof_maps writes minimal files by default, so the per-source-cell
-    # geometry (and its n_a dimension) lives in the _full companions instead.
-    for ds in (ds_nn, ds_sm):
-        assert "n_a" not in ds.sizes
-    with xr.open_dataset(get_full_map_filepath(nn_path)) as ds_nn_full:
-        with xr.open_dataset(get_full_map_filepath(sm_path)) as ds_sm_full:
-            # rof_grid is 10x10
-            assert ds_nn_full.sizes["n_a"] == ds_sm_full.sizes["n_a"] == 100
+    # every mapping file carries the per-source-cell geometry; rof_grid is 10x10
+    assert ds_nn.sizes["n_a"] == ds_sm.sizes["n_a"] == 100
 
 
-def test_gen_rof_maps_minimal_and_full_agree(tmp_path):
-    """With save_full_map=True the output pair must be self-consistent: the file
-    CESM reads carries exactly the variables ESMF's ESMF_FactorRead() needs, the
-    _full companion carries the whole CESM/SCRIP variable set, and the weights in
-    the two are identical. Also pins the requested-vs-legacy variable sets, so
-    dropping a variable ESMF does read can't pass silently."""
+def test_gen_rof_maps_writes_full_variable_set(tmp_path):
+    """Each mapping file carries the whole CESM/SCRIP variable set, including the
+    three arrays ESMF_FactorRead() actually requires. Pins the variable set so a
+    dropped variable can't pass silently."""
     rof_grid = Grid(
         resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof_min"
     )
@@ -595,27 +581,31 @@ def test_gen_rof_maps_minimal_and_full_agree(tmp_path):
         get_nn_map_filepath("m", out_dir),
         get_smoothed_map_filepath("m", out_dir, 50, 100),
     ):
-        full_path = get_full_map_filepath(path)
-        assert full_path.exists(), f"missing record-keeping companion {full_path}"
-        with xr.open_dataset(path) as ds, xr.open_dataset(full_path) as ds_full:
-            assert set(ds.variables) == set(MINIMAL_MAP_VARIABLES)
-            # "row", "col" and "S" over dimension "n_s" are what ESMF_FactorRead
-            # requires; the grid-dims arrays are two ints each and record the
-            # shape that row/col index into.
-            assert {"S", "row", "col"}.issubset(ds.variables)
+        with xr.open_dataset(path) as ds:
+            # "row", "col" and "S" over dimension "n_s" are what
+            # ESMF_FactorRead requires; the grid-dims arrays record the shape
+            # that row/col index into.
+            assert {
+                "S",
+                "row",
+                "col",
+                "src_grid_dims",
+                "dst_grid_dims",
+            }.issubset(ds.variables)
             assert ds["S"].dims == ("n_s",)
-            assert set(ds_full.variables) > set(MINIMAL_MAP_VARIABLES)
-            for var in MINIMAL_MAP_VARIABLES:
-                assert np.array_equal(ds[var].values, ds_full[var].values), var
-            # minimal must be strictly smaller - that's the entire point
-            assert path.stat().st_size < full_path.stat().st_size
+            # and the descriptive geometry, which deflate makes nearly free
+            assert {"xc_a", "yc_a", "mask_a", "area_a"}.issubset(ds.variables)
+            assert {"xc_b", "yc_b", "mask_b", "area_b"}.issubset(ds.variables)
+        companion = path.with_name(f"{path.stem}_full{path.suffix}")
+        assert not companion.exists(), f"unexpected companion file {companion}"
 
 
-def test_gen_rof_maps_full_companion_is_compressed_netcdf4(tmp_path):
-    """The CESM-facing file must stay NETCDF3_64BIT; the record-keeping companion
-    must not be held to it. Classic format cannot address a variable over 4 GiB -
-    S alone is 11.8 GiB for CrocIndoPacific_112 at rmax=100 - and nothing reads
-    the companion from CESM, so it goes out as compressed NETCDF4 instead."""
+def test_gen_rof_maps_writes_compressed_netcdf4(tmp_path):
+    """Mapping files go out as deflated NETCDF4 with int32 indices. ESMF reads
+    "row"/"col"/"S" through plain nf90_get_var with no format check, and a live
+    CESM factorial over format x index dtype x _FillValue produced bit-identical
+    mediator output for every combination - so the compression is free, and on a
+    global runoff mesh it is worth better than an order of magnitude."""
     rof_grid = Grid(
         resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof_fmt"
     )
@@ -634,18 +624,13 @@ def test_gen_rof_maps_full_companion_is_compressed_netcdf4(tmp_path):
     ):
         nc = netCDF4.Dataset(path)
         try:
-            assert nc.data_model == "NETCDF3_64BIT_OFFSET", path.name
-        finally:
-            nc.close()
-
-        full_path = get_full_map_filepath(path)
-        nc = netCDF4.Dataset(full_path)
-        try:
-            assert nc.data_model == "NETCDF4", full_path.name
-            # integers stay int32 on this path too - nothing here needs 64-bit
+            assert nc.data_model == "NETCDF4", path.name
             for name, var in nc.variables.items():
                 if np.issubdtype(var.dtype, np.integer):
                     assert var.dtype == np.int32, f"{name} is {var.dtype}"
+                # dense arrays with no missing entries - a fill attribute on
+                # them is noise some readers would turn into NaNs
+                assert "_FillValue" not in var.ncattrs(), name
         finally:
             nc.close()
 
@@ -669,11 +654,9 @@ def test_write_mapping_file_deflates_large_vars_only(tmp_path):
         dst_mesh=str(dst_path),
         filename=tmp_path / "out.nc",
         weights_coo=weights_coo,
-        minimal=True,
-        full_map_filename=tmp_path / "out_full.nc",
     )
 
-    nc = netCDF4.Dataset(tmp_path / "out_full.nc")
+    nc = netCDF4.Dataset(tmp_path / "out.nc")
     try:
         # src side is 80x80 = 6400 elements, over the deflate threshold
         assert nc.variables["xc_a"].filters()["zlib"] is True
@@ -687,10 +670,10 @@ def test_write_mapping_file_deflates_large_vars_only(tmp_path):
 
 def test_gen_rof_maps_single_precision(tmp_path):
     """single_precision=True must halve the float variables' on-disk width without
-    changing the integer indices, in both output files, and must survive the
-    nccopy -6 conversion (a float32 S is still a valid ESMF weight file:
+    changing the integer indices. A float32 S is still a valid ESMF weight file:
     ESMF_FactorRead reads it into a real(R8) buffer and netCDF converts on
-    read)."""
+    read. It is also what makes deflate effective, by collapsing the number of
+    distinct weight values."""
     rof_grid = Grid(
         resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof_sp"
     )
@@ -712,17 +695,11 @@ def test_gen_rof_maps_single_precision(tmp_path):
             fold=100,
             single_precision=single,
         )
-        # read the _full companion: it is the one that carries every float
-        # variable, so it exercises the downcast on more than just S
-        nc = netCDF4.Dataset(get_full_map_filepath(get_nn_map_filepath("m", out_dir)))
-        try:
-            dtypes[tag] = {n: v.dtype for n, v in nc.variables.items()}
-        finally:
-            nc.close()
-        # and the CESM-facing file, which must survive the nccopy -6 conversion
+        # the map carries every float variable, so this exercises the downcast
+        # on more than just S
         nc = netCDF4.Dataset(get_nn_map_filepath("m", out_dir))
         try:
-            assert nc.data_model == "NETCDF3_64BIT_OFFSET"
+            dtypes[tag] = {n: v.dtype for n, v in nc.variables.items()}
             expected = np.float32 if single else np.float64
             assert nc.variables["S"].dtype == expected
         finally:
@@ -736,29 +713,6 @@ def test_gen_rof_maps_single_precision(tmp_path):
             assert dtype == np.float32, f"{name} is {dtype}, expected float32"
         else:
             assert dtype == dtypes["f8"][name] == np.int32, name
-
-
-def test_write_mapping_file_rejects_full_without_minimal(tmp_path):
-    """A full_map_filename alongside minimal=False would be a byte-for-byte
-    duplicate of filename, so it's an error rather than a silent waste of disk."""
-    src_grid = Grid(
-        resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_dup"
-    )
-    dst_grid = Grid(
-        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_dup"
-    )
-    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
-    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
-    weights_coo = sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6))
-
-    with pytest.raises(ValueError, match="only meaningful with minimal=True"):
-        write_mapping_file(
-            src_mesh=str(src_path),
-            dst_mesh=str(dst_path),
-            filename=tmp_path / "out.nc",
-            weights_coo=weights_coo,
-            full_map_filename=tmp_path / "out_full.nc",
-        )
 
 
 def test_regrid_with_subsampling_time_dim(get_simple_grid):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -12,10 +12,10 @@ from mom6_forge.mapping import (
     _make_subgrid_points,
     regrid_with_subsampling,
     _get_mesh_bbox,
-    crop_esmf_mesh_to_bbox,
     write_mapping_file,
     gen_rof_maps,
     get_nn_map_filepath,
+    get_smoothed_map_filepath,
 )
 from mom6_forge._supergrid import haversine
 from mom6_forge.grid import Grid
@@ -327,8 +327,8 @@ def test_regrid_with_subsampling(get_simple_grid):
 
 
 # ---------------------------------------------------------------------------
-# Runoff-mapping scaling fixes: _get_mesh_bbox, crop_esmf_mesh_to_bbox, and
-# write_mapping_file's shape lookup.
+# Runoff-mapping scaling fixes: _get_mesh_bbox and write_mapping_file's shape
+# lookup / classic-format write path.
 # ---------------------------------------------------------------------------
 
 
@@ -337,38 +337,12 @@ def _write_esmf_mesh(grid, path):
     return path
 
 
-def _physical_mapping(ds):
-    """Key each nonzero mapping entry by (dst_lon, dst_lat, src_lon, src_lat)
-    instead of raw row/col index, so a cropped and an uncropped mapping (which
-    have different n_a/array sizes by design) can still be compared."""
-    xc_a, yc_a = ds["xc_a"].values, ds["yc_a"].values
-    xc_b, yc_b = ds["xc_b"].values, ds["yc_b"].values
-    row, col, S = ds["row"].values - 1, ds["col"].values - 1, ds["S"].values
-    return {
-        (
-            round(float(xc_b[r]), 6),
-            round(float(yc_b[r]), 6),
-            round(float(xc_a[c]), 6),
-            round(float(yc_a[c]), 6),
-        ): float(s)
-        for r, c, s in zip(row, col, S)
-    }
-
-
 @pytest.fixture
 def crop_rof_grid():
     """10x10 deg, 1 deg resolution, straddling the equator (lat -5..5) so
     _get_mesh_bbox's latitude handling is exercised on negative values."""
     return Grid(
         resolution=1.0, xstart=10.0, lenx=10.0, ystart=-5.0, leny=10.0, name="crop_rof"
-    )
-
-
-@pytest.fixture
-def crop_ocn_grid():
-    """3x3 deg destination domain fully inside crop_rof_grid's extent."""
-    return Grid(
-        resolution=1.0, xstart=13.0, lenx=3.0, ystart=-2.0, leny=3.0, name="crop_ocn"
     )
 
 
@@ -382,47 +356,6 @@ def test_get_mesh_bbox_preserves_negative_latitude(tmp_path, crop_rof_grid):
     # mod-360 longitude logic (that would turn -5.0 into ~355.0).
     assert lat_min == pytest.approx(-5.0)
     assert lat_max == pytest.approx(5.0)
-
-
-def test_crop_esmf_mesh_to_bbox_shrinks_to_expected_window(
-    tmp_path, crop_rof_grid, crop_ocn_grid
-):
-    rof_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
-    ocn_path = _write_esmf_mesh(crop_ocn_grid, tmp_path / "ocn.nc")
-
-    lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(ocn_path)
-    cropped_path = crop_esmf_mesh_to_bbox(
-        rof_path,
-        lon_min,
-        lon_max,
-        lat_min,
-        lat_max,
-        tmp_path / "rof_cropped.nc",
-        buffer_deg=0.5,
-    )
-
-    cropped = xr.open_dataset(cropped_path)
-    nx_c, ny_c = get_mesh_dimensions(cropped)
-    # lon centers 12.5..16.5 (buffer-widened [12.5, 16.5]), lat centers
-    # -2.5..1.5 (buffer-widened [-2.5, 1.5]) -> 5x5 window.
-    assert (nx_c, ny_c) == (5, 5)
-
-    center_lon = cropped["centerCoords"].data[:, 0].reshape(ny_c, nx_c)
-    center_lat = cropped["centerCoords"].data[:, 1].reshape(ny_c, nx_c)
-    np.testing.assert_allclose(center_lon[0, :], [12.5, 13.5, 14.5, 15.5, 16.5])
-    np.testing.assert_allclose(center_lat[:, 0], [-2.5, -1.5, -0.5, 0.5, 1.5])
-
-
-def test_crop_esmf_mesh_to_bbox_rejects_nonmonotonic_mesh(tmp_path, crop_rof_grid):
-    rof_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
-    ds = xr.open_dataset(rof_path)
-    lon = ds["centerCoords"].data[:, 0].copy()
-    lon[5] = lon[1]  # break strict monotonicity along the x-axis of row 0
-    ds["centerCoords"].data[:, 0] = lon
-    ds.to_netcdf(rof_path)
-
-    with pytest.raises(AssertionError, match="monotonic"):
-        crop_esmf_mesh_to_bbox(rof_path, 13.0, 16.0, -2.0, 1.0, tmp_path / "out.nc")
 
 
 def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
@@ -497,24 +430,12 @@ def test_write_mapping_file_produces_valid_classic_format(tmp_path):
         nc.close()
 
 
-def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(tmp_path):
-    """Cropping is purely an internal speed-up for computing weights - it must
-    not change what mesh the written mapping file claims to describe. The
-    runtime component that actually consumes this file (e.g. DROF) declares
-    its own domain as the FULL, uncropped ROF mesh, and CMEPS's remap requires
-    the mapping file's `n_a` to match that domain's element count exactly.
-    A cropped-but-mismatched `n_a` is a real, confirmed bug (found by
-    inspecting how CrocoDash wires up ROF_DOMAIN_MESH - it never gets
-    re-pointed at a cropped mesh), not just a cosmetic difference - so this
-    checks both that the mapping is physically the same AND that `n_a` did
-    not shrink.
-
-    Uses positive-latitude grids (not the equator-straddling crop_rof_grid
-    fixture): generate_ESMF_map_via_xesmf's own map_overlap masking still
-    runs latitude through normalize_deg - a separate, pre-existing bug not
-    touched by this change (see _get_mesh_bbox's docstring) - and this test
-    should check the crop, not that unrelated bug.
-    """
+def test_gen_rof_maps_end_to_end(tmp_path):
+    """Smoke test for gen_rof_maps() end-to-end (nn map + smoothing), on
+    positive-latitude grids to avoid the separate, pre-existing
+    normalize_deg(src_lat) bug in generate_ESMF_map_via_xesmf's map_overlap
+    masking (see _get_mesh_bbox's docstring) - unrelated to what this test
+    covers."""
     rof_grid = Grid(
         resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof"
     )
@@ -524,24 +445,14 @@ def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(tmp_path):
     rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof.nc")
     ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / "ocn.nc")
 
-    cropped_dir, uncropped_dir = tmp_path / "cropped", tmp_path / "uncropped"
-    gen_rof_maps(rof_path, ocn_path, cropped_dir, "test_map", crop_source_mesh=True)
-    gen_rof_maps(rof_path, ocn_path, uncropped_dir, "test_map", crop_source_mesh=False)
+    out_dir = tmp_path / "out"
+    gen_rof_maps(rof_path, ocn_path, out_dir, "test_map", rmax=50, fold=100)
 
-    ds_crop = xr.open_dataset(get_nn_map_filepath("test_map", cropped_dir))
-    ds_uncrop = xr.open_dataset(get_nn_map_filepath("test_map", uncropped_dir))
-
-    # The regression guard for the actual bug: cropping must not shrink n_a.
-    # rof_grid is 10x10 = 100 elements - if this is 900 instead, the crop
-    # window leaked into the output and the file is DROF-domain-inconsistent.
-    assert ds_crop.sizes["n_a"] == ds_uncrop.sizes["n_a"] == 100
-
-    map_crop = _physical_mapping(ds_crop)
-    map_uncrop = _physical_mapping(ds_uncrop)
-    assert map_crop, "expected at least one nonzero mapping entry"
-    assert map_crop.keys() == map_uncrop.keys()
-    for key, weight in map_crop.items():
-        assert weight == pytest.approx(map_uncrop[key], abs=1e-9)
+    ds_nn = xr.open_dataset(get_nn_map_filepath("test_map", out_dir))
+    ds_sm = xr.open_dataset(get_smoothed_map_filepath("test_map", out_dir, 50, 100))
+    assert ds_nn.sizes["n_a"] == ds_sm.sizes["n_a"] == 100  # rof_grid is 10x10
+    assert ds_nn["S"].size > 0, "expected at least one nonzero nn mapping entry"
+    assert ds_sm["S"].size > 0, "expected at least one nonzero smoothed mapping entry"
 
 
 def test_regrid_with_subsampling_time_dim(get_simple_grid):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -358,6 +358,47 @@ def test_get_mesh_bbox_preserves_negative_latitude(tmp_path, crop_rof_grid):
     assert lat_max == pytest.approx(5.0)
 
 
+def test_map_overlap_masking_is_hemisphere_symmetric(tmp_path):
+    """map_overlap must mask source cells by true latitude, not a mod-360 wrap.
+
+    generate_ESMF_map_via_xesmf() used to run source latitude through
+    normalize_deg(), turning every negative latitude into a large positive one
+    (-5 -> 355) so it compared as "north of lat_max" and got masked out. A
+    northern-hemisphere destination never noticed, which is why this went
+    unspotted; a southern one lost every source point and produced an empty
+    mapping file.
+
+    Source mesh here is symmetric about the equator, and the two destination
+    domains are exact mirror images, so the two mappings must contain the same
+    number of entries. Before the fix the southern count was 0.
+    """
+    rof_grid = Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=-10.0, leny=20.0, name="rof_sym"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof_sym.nc")
+
+    counts = {}
+    for tag, ystart in (("north", 2.0), ("south", -8.0)):
+        ocn_grid = Grid(
+            resolution=1.0, xstart=13.0, lenx=4.0, ystart=ystart, leny=6.0, name=tag
+        )
+        ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / f"ocn_{tag}.nc")
+        out_dir = tmp_path / f"out_{tag}"
+        gen_rof_maps(rof_path, ocn_path, out_dir, f"map_{tag}", rmax=50, fold=100)
+        with xr.open_dataset(get_nn_map_filepath(f"map_{tag}", out_dir)) as ds:
+            counts[tag] = int(ds["S"].size)
+
+    assert counts["north"] > 0, "northern destination should map some source cells"
+    assert counts["south"] > 0, (
+        "southern destination mapped no source cells — source latitude is being "
+        "wrapped through normalize_deg again"
+    )
+    assert counts["south"] == counts["north"], (
+        f"mirror-image domains must map equally many source cells, got "
+        f"north={counts['north']} south={counts['south']}"
+    )
+
+
 def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
     tmp_path, monkeypatch
 ):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -10,7 +10,6 @@ from mom6_forge.mapping import (
     regrid_dataset_via_cressman,
     _make_subgrid_points,
     regrid_with_subsampling,
-    _construct_vertex_coords,
     _get_mesh_bbox,
     crop_esmf_mesh_to_bbox,
     write_mapping_file,
@@ -327,8 +326,8 @@ def test_regrid_with_subsampling(get_simple_grid):
 
 
 # ---------------------------------------------------------------------------
-# Runoff-mapping scaling fixes: _get_mesh_bbox, crop_esmf_mesh_to_bbox,
-# vectorized _construct_vertex_coords, and write_mapping_file's shape lookup.
+# Runoff-mapping scaling fixes: _get_mesh_bbox, crop_esmf_mesh_to_bbox, and
+# write_mapping_file's shape lookup.
 # ---------------------------------------------------------------------------
 
 
@@ -337,32 +336,22 @@ def _write_esmf_mesh(grid, path):
     return path
 
 
-def _set_element_mask(mesh_path, mask_2d):
-    """Overwrite elementMask on an existing ESMF mesh file with a (ny, nx) mask."""
-    ds = xr.open_dataset(mesh_path)
-    ds = ds.assign(
-        elementMask=(("elementCount",), mask_2d.ravel().astype(ds["elementMask"].dtype))
-    )
-    ds.to_netcdf(mesh_path)
-
-
-def _physical_mapping_set(ds):
-    """Key each nonzero mapping entry by (dst_lon, dst_lat, src_lon, src_lat) instead
-    of raw row/col index, so mappings built from differently-shaped source meshes
-    (e.g. cropped vs. uncropped) can still be compared for equivalence."""
+def _physical_mapping(ds):
+    """Key each nonzero mapping entry by (dst_lon, dst_lat, src_lon, src_lat)
+    instead of raw row/col index, so a cropped and an uncropped mapping (which
+    have different n_a/array sizes by design) can still be compared."""
     xc_a, yc_a = ds["xc_a"].values, ds["yc_a"].values
     xc_b, yc_b = ds["xc_b"].values, ds["yc_b"].values
     row, col, S = ds["row"].values - 1, ds["col"].values - 1, ds["S"].values
-    out = {}
-    for r, c, s in zip(row, col, S):
-        key = (
+    return {
+        (
             round(float(xc_b[r]), 6),
             round(float(yc_b[r]), 6),
             round(float(xc_a[c]), 6),
             round(float(yc_a[c]), 6),
-        )
-        out[key] = out.get(key, 0.0) + float(s)
-    return out
+        ): float(s)
+        for r, c, s in zip(row, col, S)
+    }
 
 
 @pytest.fixture
@@ -379,39 +368,6 @@ def crop_ocn_grid():
     """3x3 deg destination domain fully inside crop_rof_grid's extent."""
     return Grid(
         resolution=1.0, xstart=13.0, lenx=3.0, ystart=-2.0, leny=3.0, name="crop_ocn"
-    )
-
-
-@pytest.fixture
-def crop_rof_grid_pos_lat():
-    """Same footprint as crop_rof_grid but shifted to all-positive latitude.
-
-    generate_ESMF_map_via_xesmf's map_overlap masking (mapping.py) still runs
-    src_lat through normalize_deg (a separate, pre-existing bug not fixed by
-    this branch - see _get_mesh_bbox's docstring) - straddling the equator
-    there would wrap negative latitudes and mask out the wrong cells. Tests
-    that exercise the actual regridder go through this fixture instead of
-    crop_rof_grid so they check the crop, not that unrelated bug.
-    """
-    return Grid(
-        resolution=1.0,
-        xstart=10.0,
-        lenx=10.0,
-        ystart=25.0,
-        leny=10.0,
-        name="crop_rof_pos",
-    )
-
-
-@pytest.fixture
-def crop_ocn_grid_pos_lat():
-    return Grid(
-        resolution=1.0,
-        xstart=13.0,
-        lenx=3.0,
-        ystart=28.0,
-        leny=3.0,
-        name="crop_ocn_pos",
     )
 
 
@@ -432,12 +388,6 @@ def test_crop_esmf_mesh_to_bbox_shrinks_to_expected_window(
 ):
     rof_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
     ocn_path = _write_esmf_mesh(crop_ocn_grid, tmp_path / "ocn.nc")
-
-    # Mark a single active cell at rof grid indices (i=4, j=4) -> lon center
-    # 14.5, lat center -0.5 - inside the crop window computed below.
-    full_mask = np.zeros((10, 10))
-    full_mask[4, 4] = 1
-    _set_element_mask(rof_path, full_mask)
 
     lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(ocn_path)
     cropped_path = crop_esmf_mesh_to_bbox(
@@ -461,14 +411,6 @@ def test_crop_esmf_mesh_to_bbox_shrinks_to_expected_window(
     np.testing.assert_allclose(center_lon[0, :], [12.5, 13.5, 14.5, 15.5, 16.5])
     np.testing.assert_allclose(center_lat[:, 0], [-2.5, -1.5, -0.5, 0.5, 1.5])
 
-    # The single active cell (global i=4, j=4) sits at local (i=2, j=2) in the
-    # cropped window (imin=jmin=2) - crop must preserve mask *position*, not
-    # just mask *values*.
-    mask_c = cropped["elementMask"].data.reshape(ny_c, nx_c)
-    expected_mask = np.zeros((5, 5))
-    expected_mask[2, 2] = 1
-    np.testing.assert_array_equal(mask_c, expected_mask)
-
 
 def test_crop_esmf_mesh_to_bbox_rejects_nonmonotonic_mesh(tmp_path, crop_rof_grid):
     rof_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
@@ -480,58 +422,6 @@ def test_crop_esmf_mesh_to_bbox_rejects_nonmonotonic_mesh(tmp_path, crop_rof_gri
 
     with pytest.raises(AssertionError, match="monotonic"):
         crop_esmf_mesh_to_bbox(rof_path, 13.0, 16.0, -2.0, 1.0, tmp_path / "out.nc")
-
-
-def test_construct_vertex_coords_vectorized_quads_and_triangle():
-    node_coords = np.array(
-        [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]
-    )
-    # 1-based connectivity; third row is a triangle (NaN in the 4th slot).
-    element_conn = np.array(
-        [
-            [1, 2, 5, 4],
-            [2, 3, 6, 5],
-            [1, 2, 5, np.nan],
-        ]
-    )
-    mesh = xr.Dataset(
-        {
-            "nodeCoords": (("nodeCount", "coordDim"), node_coords),
-            "elementConn": (("elementCount", "maxNodePElement"), element_conn),
-        }
-    )
-
-    xv, yv = _construct_vertex_coords(mesh)
-
-    expected_xv = np.array(
-        [[0.0, 1.0, 1.0, 0.0], [1.0, 2.0, 2.0, 1.0], [0.0, 1.0, 1.0, 1.0]]
-    )
-    expected_yv = np.array(
-        [[0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 1.0]]
-    )
-    np.testing.assert_allclose(xv, expected_xv)
-    np.testing.assert_allclose(yv, expected_yv)
-
-
-def test_construct_vertex_coords_matches_reference_loop(crop_rof_grid, tmp_path):
-    """Cross-check the vectorized implementation against a plain-Python
-    reference loop (the pre-vectorization algorithm) on a real, all-quad mesh."""
-    mesh_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
-    mesh = xr.open_dataset(mesh_path)
-
-    element_conn = mesh.elementConn.data - 1
-    node_coords = mesh.nodeCoords.data
-    xv_loop = np.zeros(element_conn.shape)
-    yv_loop = np.zeros(element_conn.shape)
-    for e, nodes in enumerate(element_conn):
-        for v in range(4):
-            idx = nodes[2] if np.isnan(nodes[v]) else nodes[v]
-            xv_loop[e, v] = node_coords[int(idx), 0]
-            yv_loop[e, v] = node_coords[int(idx), 1]
-
-    xv_vec, yv_vec = _construct_vertex_coords(mesh)
-    np.testing.assert_allclose(xv_vec, xv_loop)
-    np.testing.assert_allclose(yv_vec, yv_loop)
 
 
 def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
@@ -565,66 +455,46 @@ def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
     ds = xr.open_dataset(out_path)
     assert list(ds["src_grid_dims"].values) == [3, 2]
     assert list(ds["dst_grid_dims"].values) == [2, 2]
-    assert ds.sizes["nj_a"] == 2 and ds.sizes["ni_a"] == 3
-    assert ds.sizes["nj_b"] == 2 and ds.sizes["ni_b"] == 2
 
 
-def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(
-    tmp_path, crop_rof_grid_pos_lat, crop_ocn_grid_pos_lat
-):
+def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(tmp_path):
     """The whole point of cropping is that it must not change the actual
     regridding result, only the array size it's computed over. Compare
     cropped vs. uncropped gen_rof_maps() output by physical (lon, lat)
-    mapping rather than raw index, since cropping intentionally changes
-    n_a/array shape."""
-    rof_path = _write_esmf_mesh(crop_rof_grid_pos_lat, tmp_path / "rof.nc")
-    ocn_path = _write_esmf_mesh(crop_ocn_grid_pos_lat, tmp_path / "ocn.nc")
+    mapping rather than raw index, since cropping intentionally shrinks
+    n_a (this is as close to "bit for bit" as two differently-shaped
+    mesh files can be compared - every weight must land on the exact
+    same physical source/destination pair).
 
-    # Sparse, non-trivial mask (checkerboard) so the mapping isn't a
-    # degenerate all-active case.
-    checkerboard = np.zeros((10, 10))
-    checkerboard[::2, ::2] = 1
-    _set_element_mask(rof_path, checkerboard)
-
-    cropped_dir = tmp_path / "cropped"
-    uncropped_dir = tmp_path / "uncropped"
-    gen_rof_maps(
-        rof_path,
-        ocn_path,
-        cropped_dir,
-        "test_map",
-        rmax=200,
-        fold=400,
-        crop_source_mesh=True,
+    Uses positive-latitude grids (not the equator-straddling crop_rof_grid
+    fixture): generate_ESMF_map_via_xesmf's own map_overlap masking still
+    runs latitude through normalize_deg - a separate, pre-existing bug not
+    touched by this change (see _get_mesh_bbox's docstring) - and this test
+    should check the crop, not that unrelated bug.
+    """
+    rof_grid = Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof"
     )
-    gen_rof_maps(
-        rof_path,
-        ocn_path,
-        uncropped_dir,
-        "test_map",
-        rmax=200,
-        fold=400,
-        crop_source_mesh=False,
+    ocn_grid = Grid(
+        resolution=1.0, xstart=13.0, lenx=3.0, ystart=28.0, leny=3.0, name="ocn"
     )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof.nc")
+    ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / "ocn.nc")
 
-    from mom6_forge.mapping import get_smoothed_map_filepath
+    cropped_dir, uncropped_dir = tmp_path / "cropped", tmp_path / "uncropped"
+    gen_rof_maps(rof_path, ocn_path, cropped_dir, "test_map", crop_source_mesh=True)
+    gen_rof_maps(rof_path, ocn_path, uncropped_dir, "test_map", crop_source_mesh=False)
 
-    for cropped_file, uncropped_file in [
-        (
-            get_nn_map_filepath("test_map", cropped_dir),
-            get_nn_map_filepath("test_map", uncropped_dir),
-        ),
-        (
-            get_smoothed_map_filepath("test_map", cropped_dir, 200, 400),
-            get_smoothed_map_filepath("test_map", uncropped_dir, 200, 400),
-        ),
-    ]:
-        map_crop = _physical_mapping_set(xr.open_dataset(cropped_file))
-        map_uncrop = _physical_mapping_set(xr.open_dataset(uncropped_file))
-        assert map_crop, "expected at least one nonzero mapping entry"
-        assert set(map_crop) == set(map_uncrop)
-        for key, weight in map_crop.items():
-            assert weight == pytest.approx(map_uncrop[key], abs=1e-9)
+    map_crop = _physical_mapping(
+        xr.open_dataset(get_nn_map_filepath("test_map", cropped_dir))
+    )
+    map_uncrop = _physical_mapping(
+        xr.open_dataset(get_nn_map_filepath("test_map", uncropped_dir))
+    )
+    assert map_crop, "expected at least one nonzero mapping entry"
+    assert map_crop.keys() == map_uncrop.keys()
+    for key, weight in map_crop.items():
+        assert weight == pytest.approx(map_uncrop[key], abs=1e-9)
 
 
 def test_regrid_with_subsampling_time_dim(get_simple_grid):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,6 +1,7 @@
 import xarray as xr
 import numpy as np
 import scipy.sparse as sp
+import pytest
 from pathlib import Path
 from mom6_forge.mapping import (
     compute_cressman_weights,
@@ -9,8 +10,16 @@ from mom6_forge.mapping import (
     regrid_dataset_via_cressman,
     _make_subgrid_points,
     regrid_with_subsampling,
+    _construct_vertex_coords,
+    _get_mesh_bbox,
+    crop_esmf_mesh_to_bbox,
+    write_mapping_file,
+    gen_rof_maps,
+    get_nn_map_filepath,
 )
 from mom6_forge._supergrid import haversine
+from mom6_forge.grid import Grid
+from mom6_forge.utils import get_mesh_dimensions
 
 
 def make_synthetic_grids():
@@ -315,6 +324,307 @@ def test_regrid_with_subsampling(get_simple_grid):
     assert np.allclose(
         ds["data"].values, expected_data
     ), "Regridded data does not match expected values."
+
+
+# ---------------------------------------------------------------------------
+# Runoff-mapping scaling fixes: _get_mesh_bbox, crop_esmf_mesh_to_bbox,
+# vectorized _construct_vertex_coords, and write_mapping_file's shape lookup.
+# ---------------------------------------------------------------------------
+
+
+def _write_esmf_mesh(grid, path):
+    grid.supergrid.to_esmf_mesh(str(path), mask="all_unmasked")
+    return path
+
+
+def _set_element_mask(mesh_path, mask_2d):
+    """Overwrite elementMask on an existing ESMF mesh file with a (ny, nx) mask."""
+    ds = xr.open_dataset(mesh_path)
+    ds = ds.assign(
+        elementMask=(("elementCount",), mask_2d.ravel().astype(ds["elementMask"].dtype))
+    )
+    ds.to_netcdf(mesh_path)
+
+
+def _physical_mapping_set(ds):
+    """Key each nonzero mapping entry by (dst_lon, dst_lat, src_lon, src_lat) instead
+    of raw row/col index, so mappings built from differently-shaped source meshes
+    (e.g. cropped vs. uncropped) can still be compared for equivalence."""
+    xc_a, yc_a = ds["xc_a"].values, ds["yc_a"].values
+    xc_b, yc_b = ds["xc_b"].values, ds["yc_b"].values
+    row, col, S = ds["row"].values - 1, ds["col"].values - 1, ds["S"].values
+    out = {}
+    for r, c, s in zip(row, col, S):
+        key = (
+            round(float(xc_b[r]), 6),
+            round(float(yc_b[r]), 6),
+            round(float(xc_a[c]), 6),
+            round(float(yc_a[c]), 6),
+        )
+        out[key] = out.get(key, 0.0) + float(s)
+    return out
+
+
+@pytest.fixture
+def crop_rof_grid():
+    """10x10 deg, 1 deg resolution, straddling the equator (lat -5..5) so
+    _get_mesh_bbox's latitude handling is exercised on negative values."""
+    return Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=-5.0, leny=10.0, name="crop_rof"
+    )
+
+
+@pytest.fixture
+def crop_ocn_grid():
+    """3x3 deg destination domain fully inside crop_rof_grid's extent."""
+    return Grid(
+        resolution=1.0, xstart=13.0, lenx=3.0, ystart=-2.0, leny=3.0, name="crop_ocn"
+    )
+
+
+@pytest.fixture
+def crop_rof_grid_pos_lat():
+    """Same footprint as crop_rof_grid but shifted to all-positive latitude.
+
+    generate_ESMF_map_via_xesmf's map_overlap masking (mapping.py) still runs
+    src_lat through normalize_deg (a separate, pre-existing bug not fixed by
+    this branch - see _get_mesh_bbox's docstring) - straddling the equator
+    there would wrap negative latitudes and mask out the wrong cells. Tests
+    that exercise the actual regridder go through this fixture instead of
+    crop_rof_grid so they check the crop, not that unrelated bug.
+    """
+    return Grid(
+        resolution=1.0,
+        xstart=10.0,
+        lenx=10.0,
+        ystart=25.0,
+        leny=10.0,
+        name="crop_rof_pos",
+    )
+
+
+@pytest.fixture
+def crop_ocn_grid_pos_lat():
+    return Grid(
+        resolution=1.0,
+        xstart=13.0,
+        lenx=3.0,
+        ystart=28.0,
+        leny=3.0,
+        name="crop_ocn_pos",
+    )
+
+
+def test_get_mesh_bbox_preserves_negative_latitude(tmp_path, crop_rof_grid):
+    mesh_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
+    lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(mesh_path)
+
+    assert lon_min == pytest.approx(10.0)
+    assert lon_max == pytest.approx(20.0)
+    # Regression guard: latitude must NOT be wrapped through normalize_deg's
+    # mod-360 longitude logic (that would turn -5.0 into ~355.0).
+    assert lat_min == pytest.approx(-5.0)
+    assert lat_max == pytest.approx(5.0)
+
+
+def test_crop_esmf_mesh_to_bbox_shrinks_to_expected_window(
+    tmp_path, crop_rof_grid, crop_ocn_grid
+):
+    rof_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
+    ocn_path = _write_esmf_mesh(crop_ocn_grid, tmp_path / "ocn.nc")
+
+    # Mark a single active cell at rof grid indices (i=4, j=4) -> lon center
+    # 14.5, lat center -0.5 - inside the crop window computed below.
+    full_mask = np.zeros((10, 10))
+    full_mask[4, 4] = 1
+    _set_element_mask(rof_path, full_mask)
+
+    lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(ocn_path)
+    cropped_path = crop_esmf_mesh_to_bbox(
+        rof_path,
+        lon_min,
+        lon_max,
+        lat_min,
+        lat_max,
+        tmp_path / "rof_cropped.nc",
+        buffer_deg=0.5,
+    )
+
+    cropped = xr.open_dataset(cropped_path)
+    nx_c, ny_c = get_mesh_dimensions(cropped)
+    # lon centers 12.5..16.5 (buffer-widened [12.5, 16.5]), lat centers
+    # -2.5..1.5 (buffer-widened [-2.5, 1.5]) -> 5x5 window.
+    assert (nx_c, ny_c) == (5, 5)
+
+    center_lon = cropped["centerCoords"].data[:, 0].reshape(ny_c, nx_c)
+    center_lat = cropped["centerCoords"].data[:, 1].reshape(ny_c, nx_c)
+    np.testing.assert_allclose(center_lon[0, :], [12.5, 13.5, 14.5, 15.5, 16.5])
+    np.testing.assert_allclose(center_lat[:, 0], [-2.5, -1.5, -0.5, 0.5, 1.5])
+
+    # The single active cell (global i=4, j=4) sits at local (i=2, j=2) in the
+    # cropped window (imin=jmin=2) - crop must preserve mask *position*, not
+    # just mask *values*.
+    mask_c = cropped["elementMask"].data.reshape(ny_c, nx_c)
+    expected_mask = np.zeros((5, 5))
+    expected_mask[2, 2] = 1
+    np.testing.assert_array_equal(mask_c, expected_mask)
+
+
+def test_crop_esmf_mesh_to_bbox_rejects_nonmonotonic_mesh(tmp_path, crop_rof_grid):
+    rof_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
+    ds = xr.open_dataset(rof_path)
+    lon = ds["centerCoords"].data[:, 0].copy()
+    lon[5] = lon[1]  # break strict monotonicity along the x-axis of row 0
+    ds["centerCoords"].data[:, 0] = lon
+    ds.to_netcdf(rof_path)
+
+    with pytest.raises(AssertionError, match="monotonic"):
+        crop_esmf_mesh_to_bbox(rof_path, 13.0, 16.0, -2.0, 1.0, tmp_path / "out.nc")
+
+
+def test_construct_vertex_coords_vectorized_quads_and_triangle():
+    node_coords = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]
+    )
+    # 1-based connectivity; third row is a triangle (NaN in the 4th slot).
+    element_conn = np.array(
+        [
+            [1, 2, 5, 4],
+            [2, 3, 6, 5],
+            [1, 2, 5, np.nan],
+        ]
+    )
+    mesh = xr.Dataset(
+        {
+            "nodeCoords": (("nodeCount", "coordDim"), node_coords),
+            "elementConn": (("elementCount", "maxNodePElement"), element_conn),
+        }
+    )
+
+    xv, yv = _construct_vertex_coords(mesh)
+
+    expected_xv = np.array(
+        [[0.0, 1.0, 1.0, 0.0], [1.0, 2.0, 2.0, 1.0], [0.0, 1.0, 1.0, 1.0]]
+    )
+    expected_yv = np.array(
+        [[0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 1.0]]
+    )
+    np.testing.assert_allclose(xv, expected_xv)
+    np.testing.assert_allclose(yv, expected_yv)
+
+
+def test_construct_vertex_coords_matches_reference_loop(crop_rof_grid, tmp_path):
+    """Cross-check the vectorized implementation against a plain-Python
+    reference loop (the pre-vectorization algorithm) on a real, all-quad mesh."""
+    mesh_path = _write_esmf_mesh(crop_rof_grid, tmp_path / "rof.nc")
+    mesh = xr.open_dataset(mesh_path)
+
+    element_conn = mesh.elementConn.data - 1
+    node_coords = mesh.nodeCoords.data
+    xv_loop = np.zeros(element_conn.shape)
+    yv_loop = np.zeros(element_conn.shape)
+    for e, nodes in enumerate(element_conn):
+        for v in range(4):
+            idx = nodes[2] if np.isnan(nodes[v]) else nodes[v]
+            xv_loop[e, v] = node_coords[int(idx), 0]
+            yv_loop[e, v] = node_coords[int(idx), 1]
+
+    xv_vec, yv_vec = _construct_vertex_coords(mesh)
+    np.testing.assert_allclose(xv_vec, xv_loop)
+    np.testing.assert_allclose(yv_vec, yv_loop)
+
+
+def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
+    tmp_path, monkeypatch
+):
+    """write_mapping_file only ever needs each mesh's (nx, ny) shape - it must not
+    reconstruct full mesh geometry (Topo.from_esmf_mesh) just to get that shape."""
+    src_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_shape"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_shape"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("write_mapping_file must not call Topo.from_esmf_mesh")
+
+    monkeypatch.setattr("mom6_forge.topo.Topo.from_esmf_mesh", _boom)
+
+    weights_coo = sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6))
+    out_path = tmp_path / "out.nc"
+    write_mapping_file(
+        src_mesh=str(src_path),
+        dst_mesh=str(dst_path),
+        filename=out_path,
+        weights_coo=weights_coo,
+    )
+
+    ds = xr.open_dataset(out_path)
+    assert list(ds["src_grid_dims"].values) == [3, 2]
+    assert list(ds["dst_grid_dims"].values) == [2, 2]
+    assert ds.sizes["nj_a"] == 2 and ds.sizes["ni_a"] == 3
+    assert ds.sizes["nj_b"] == 2 and ds.sizes["ni_b"] == 2
+
+
+def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(
+    tmp_path, crop_rof_grid_pos_lat, crop_ocn_grid_pos_lat
+):
+    """The whole point of cropping is that it must not change the actual
+    regridding result, only the array size it's computed over. Compare
+    cropped vs. uncropped gen_rof_maps() output by physical (lon, lat)
+    mapping rather than raw index, since cropping intentionally changes
+    n_a/array shape."""
+    rof_path = _write_esmf_mesh(crop_rof_grid_pos_lat, tmp_path / "rof.nc")
+    ocn_path = _write_esmf_mesh(crop_ocn_grid_pos_lat, tmp_path / "ocn.nc")
+
+    # Sparse, non-trivial mask (checkerboard) so the mapping isn't a
+    # degenerate all-active case.
+    checkerboard = np.zeros((10, 10))
+    checkerboard[::2, ::2] = 1
+    _set_element_mask(rof_path, checkerboard)
+
+    cropped_dir = tmp_path / "cropped"
+    uncropped_dir = tmp_path / "uncropped"
+    gen_rof_maps(
+        rof_path,
+        ocn_path,
+        cropped_dir,
+        "test_map",
+        rmax=200,
+        fold=400,
+        crop_source_mesh=True,
+    )
+    gen_rof_maps(
+        rof_path,
+        ocn_path,
+        uncropped_dir,
+        "test_map",
+        rmax=200,
+        fold=400,
+        crop_source_mesh=False,
+    )
+
+    from mom6_forge.mapping import get_smoothed_map_filepath
+
+    for cropped_file, uncropped_file in [
+        (
+            get_nn_map_filepath("test_map", cropped_dir),
+            get_nn_map_filepath("test_map", uncropped_dir),
+        ),
+        (
+            get_smoothed_map_filepath("test_map", cropped_dir, 200, 400),
+            get_smoothed_map_filepath("test_map", uncropped_dir, 200, 400),
+        ),
+    ]:
+        map_crop = _physical_mapping_set(xr.open_dataset(cropped_file))
+        map_uncrop = _physical_mapping_set(xr.open_dataset(uncropped_file))
+        assert map_crop, "expected at least one nonzero mapping entry"
+        assert set(map_crop) == set(map_uncrop)
+        for key, weight in map_crop.items():
+            assert weight == pytest.approx(map_uncrop[key], abs=1e-9)
 
 
 def test_regrid_with_subsampling_time_dim(get_simple_grid):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -4,6 +4,7 @@ import netCDF4
 import scipy.sparse as sp
 import pytest
 from pathlib import Path
+from mom6_forge import mapping
 from mom6_forge.mapping import (
     compute_cressman_weights,
     dst_to_source,
@@ -754,3 +755,60 @@ def test_regrid_with_subsampling_time_dim(get_simple_grid):
         assert np.allclose(
             ds["data"].values[t], expected_spatial
         ), f"Regridded data at t={t} does not match expected values."
+
+
+def test_pad_weights_for_esmf_is_noop_below_threshold():
+    """Below 2**24 the float32 PET split in ESMF_FactorRead is provably exact,
+    so nothing is added - a small map must come out byte-for-byte as built."""
+    S = xr.DataArray(np.array([0.5, 0.25, 0.25]), dims=["n_s"])
+    row = xr.DataArray(np.array([7, 7, 9], dtype="i4"), dims=["n_s"])
+    col = xr.DataArray(np.array([3, 4, 5], dtype="i4"), dims=["n_s"])
+
+    S2, row2, col2 = mapping._pad_weights_for_esmf(S, row, col)
+
+    assert S2.sizes["n_s"] == 3
+    assert np.array_equal(S2.values, S.values)
+    assert np.array_equal(row2.values, row.values)
+    assert np.array_equal(col2.values, col.values)
+
+
+def test_pad_weights_for_esmf_aligns_and_stays_inert(monkeypatch):
+    """Above the threshold n_s is rounded up to a multiple of 1024 with
+    zero-weight entries that reuse the first real (row, col) pair.
+
+    Reusing an existing pair matters: a pair the map does not otherwise use
+    would pull an extra source cell into the route handle, and 0 * NaN would
+    then poison its destination cell. ESMF sums duplicate index pairs.
+    """
+    monkeypatch.setattr(mapping, "_ESMF_FACTORREAD_EXACT_MAX", 4)
+    n = 1500
+    S = xr.DataArray(np.linspace(0.1, 0.9, n), dims=["n_s"])
+    row = xr.DataArray(np.arange(1, n + 1, dtype="i4"), dims=["n_s"])
+    col = xr.DataArray(np.arange(101, 101 + n, dtype="i4"), dims=["n_s"])
+
+    S2, row2, col2 = mapping._pad_weights_for_esmf(S, row, col)
+
+    assert S2.sizes["n_s"] == 2048
+    assert S2.sizes["n_s"] % mapping._N_S_ALIGNMENT == 0
+    # the real weights are untouched, and the pad contributes nothing
+    assert np.array_equal(S2.values[:n], S.values)
+    assert (S2.values[n:] == 0).all()
+    assert S2.values.sum() == pytest.approx(S.values.sum())
+    # the pad introduces no source or destination cell the map didn't already use
+    assert (row2.values[n:] == row.values[0]).all()
+    assert (col2.values[n:] == col.values[0]).all()
+    assert set(np.unique(row2.values)) == set(np.unique(row.values))
+    assert set(np.unique(col2.values)) == set(np.unique(col.values))
+    assert row2.dtype == row.dtype and col2.dtype == col.dtype
+
+
+def test_pad_weights_for_esmf_rejects_unfixable_size(monkeypatch):
+    """Past 2**33 a 1024 alignment no longer lands on an exact float32 value, so
+    padding cannot make the split safe - fail loudly rather than pretend."""
+    monkeypatch.setattr(mapping, "_ESMF_FACTORREAD_EXACT_MAX", 4)
+
+    class _Fake:
+        sizes = {"n_s": 2**33 + 7}
+
+    with pytest.raises(ValueError, match=r"2\*\*33"):
+        mapping._pad_weights_for_esmf(_Fake(), None, None)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -399,6 +399,72 @@ def test_map_overlap_masking_is_hemisphere_symmetric(tmp_path):
     )
 
 
+def test_get_mesh_bbox_handles_0_360_seam(tmp_path):
+    """A mesh whose eastern edge is exactly lon 360 must not report a global bbox.
+
+    normalize_deg is mod(x + 360, 360), so nodes sitting on exactly 360 come back
+    as 0. Taking min()/max() of that then reports 0.00..359.x - nearly the whole
+    globe - for a mesh spanning ten degrees. Downstream that turned
+    generate_ESMF_map_via_xesmf's map_overlap masking into a no-op in longitude,
+    so the regrid ran against a global latitude band; a 576K-cell domain went from
+    106 s to not finishing in over an hour.
+
+    The interval is allowed to wrap (lon_min > lon_max) - that is how a
+    seam-crossing domain is expressed - so what this asserts is the *width*.
+    """
+    grid = Grid(
+        resolution=1.0, xstart=350.0, lenx=10.0, ystart=-3.0, leny=6.0, name="seam"
+    )
+    mesh_path = _write_esmf_mesh(grid, tmp_path / "seam.nc")
+    lon_min, lon_max, lat_min, lat_max = _get_mesh_bbox(mesh_path)
+
+    width = lon_max - lon_min if lon_max >= lon_min else 360.0 - lon_min + lon_max
+    assert width == pytest.approx(10.0), (
+        f"bbox spans {width:.2f} deg for a 10 deg mesh - longitudes touching the "
+        f"0/360 seam are being collapsed by normalize_deg again "
+        f"(got lon_min={lon_min}, lon_max={lon_max})"
+    )
+    assert lon_min == pytest.approx(350.0)
+    assert lat_min == pytest.approx(-3.0)
+    assert lat_max == pytest.approx(3.0)
+
+
+def test_map_overlap_masking_is_rotation_invariant(tmp_path):
+    """map_overlap must mask the same way whether or not the domain touches lon 360.
+
+    Companion to test_map_overlap_masking_is_hemisphere_symmetric: that one covers
+    latitude, this one longitude. The source mesh is uniform in longitude, so two
+    destination windows of equal width must select equally many source cells no
+    matter where they sit. Before the fix the seam window's bbox came back as
+    ~0..359, masked nothing, and mapped the entire source mesh - three times as
+    many cells as the interior window.
+    """
+    rof_grid = Grid(
+        resolution=1.0, xstart=330.0, lenx=30.0, ystart=-5.0, leny=10.0, name="rof_rot"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof_rot.nc")
+
+    counts = {}
+    # "seam" ends on exactly lon 360; "interior" is the same width, 10 deg west.
+    for tag, xstart in (("seam", 350.0), ("interior", 340.0)):
+        ocn_grid = Grid(
+            resolution=1.0, xstart=xstart, lenx=10.0, ystart=-3.0, leny=6.0, name=tag
+        )
+        ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / f"ocn_{tag}.nc")
+        out_dir = tmp_path / f"out_{tag}"
+        gen_rof_maps(rof_path, ocn_path, out_dir, f"map_{tag}", rmax=50, fold=100)
+        with xr.open_dataset(get_nn_map_filepath(f"map_{tag}", out_dir)) as ds:
+            counts[tag] = int(ds["S"].size)
+
+    assert counts["interior"] > 0, "interior destination should map some source cells"
+    assert counts["seam"] == counts["interior"], (
+        f"equal-width domains must map equally many source cells regardless of "
+        f"where they sit in longitude, got seam={counts['seam']} "
+        f"interior={counts['interior']} - the domain touching lon 360 is getting a "
+        f"near-global bbox again, so map_overlap masks nothing"
+    )
+
+
 def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
     tmp_path, monkeypatch
 ):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -458,13 +458,16 @@ def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
 
 
 def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(tmp_path):
-    """The whole point of cropping is that it must not change the actual
-    regridding result, only the array size it's computed over. Compare
-    cropped vs. uncropped gen_rof_maps() output by physical (lon, lat)
-    mapping rather than raw index, since cropping intentionally shrinks
-    n_a (this is as close to "bit for bit" as two differently-shaped
-    mesh files can be compared - every weight must land on the exact
-    same physical source/destination pair).
+    """Cropping is purely an internal speed-up for computing weights - it must
+    not change what mesh the written mapping file claims to describe. The
+    runtime component that actually consumes this file (e.g. DROF) declares
+    its own domain as the FULL, uncropped ROF mesh, and CMEPS's remap requires
+    the mapping file's `n_a` to match that domain's element count exactly.
+    A cropped-but-mismatched `n_a` is a real, confirmed bug (found by
+    inspecting how CrocoDash wires up ROF_DOMAIN_MESH - it never gets
+    re-pointed at a cropped mesh), not just a cosmetic difference - so this
+    checks both that the mapping is physically the same AND that `n_a` did
+    not shrink.
 
     Uses positive-latitude grids (not the equator-straddling crop_rof_grid
     fixture): generate_ESMF_map_via_xesmf's own map_overlap masking still
@@ -485,12 +488,16 @@ def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(tmp_path):
     gen_rof_maps(rof_path, ocn_path, cropped_dir, "test_map", crop_source_mesh=True)
     gen_rof_maps(rof_path, ocn_path, uncropped_dir, "test_map", crop_source_mesh=False)
 
-    map_crop = _physical_mapping(
-        xr.open_dataset(get_nn_map_filepath("test_map", cropped_dir))
-    )
-    map_uncrop = _physical_mapping(
-        xr.open_dataset(get_nn_map_filepath("test_map", uncropped_dir))
-    )
+    ds_crop = xr.open_dataset(get_nn_map_filepath("test_map", cropped_dir))
+    ds_uncrop = xr.open_dataset(get_nn_map_filepath("test_map", uncropped_dir))
+
+    # The regression guard for the actual bug: cropping must not shrink n_a.
+    # rof_grid is 10x10 = 100 elements - if this is 900 instead, the crop
+    # window leaked into the output and the file is DROF-domain-inconsistent.
+    assert ds_crop.sizes["n_a"] == ds_uncrop.sizes["n_a"] == 100
+
+    map_crop = _physical_mapping(ds_crop)
+    map_uncrop = _physical_mapping(ds_uncrop)
     assert map_crop, "expected at least one nonzero mapping entry"
     assert map_crop.keys() == map_uncrop.keys()
     for key, weight in map_crop.items():

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,5 +1,6 @@
 import xarray as xr
 import numpy as np
+import netCDF4
 import scipy.sparse as sp
 import pytest
 from pathlib import Path
@@ -455,6 +456,45 @@ def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
     ds = xr.open_dataset(out_path)
     assert list(ds["src_grid_dims"].values) == [3, 2]
     assert list(ds["dst_grid_dims"].values) == [2, 2]
+
+
+def test_write_mapping_file_produces_valid_classic_format(tmp_path):
+    """write_mapping_file writes via an intermediate NETCDF4 file converted with
+    `nccopy -6` (much faster than writing NETCDF3_64BIT directly - see NOTES.md
+    Step 9), but the output must still be a genuine 64-bit-offset classic file,
+    since that's what CESM's mapping-file readers require. Also guards the
+    int64-vs-classic-format bug found while implementing this: `nj_a`/`ni_a`/
+    `nj_b`/`ni_b` are coordinate variables (their DataArray name matches their
+    sole dimension), so an encoding loop scoped to `ds.data_vars` silently skips
+    them and leaves them as int64 - a dtype classic format can't represent at
+    all, which makes `nccopy` fail outright. Every integer variable, coordinate
+    or not, must come out as int32."""
+    src_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_classic"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_classic"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+
+    weights_coo = sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6))
+    out_path = tmp_path / "out.nc"
+    write_mapping_file(
+        src_mesh=str(src_path),
+        dst_mesh=str(dst_path),
+        filename=out_path,
+        weights_coo=weights_coo,
+    )
+
+    nc = netCDF4.Dataset(out_path)
+    try:
+        assert nc.data_model == "NETCDF3_64BIT_OFFSET"
+        for name, var in nc.variables.items():
+            if np.issubdtype(var.dtype, np.integer):
+                assert var.dtype == np.int32, f"{name} is {var.dtype}, expected int32"
+    finally:
+        nc.close()
 
 
 def test_gen_rof_maps_crop_matches_uncropped_physical_mapping(tmp_path):


### PR DESCRIPTION
Changes:

1. Fix a regression where we reconstructed the Topo object from esmf mesh to just getting the grid dimensions.

2. Write mapping files as compressed netCDF4, in single precision -> drops the memory significantly and is much faster. (Didn't use to run in the CESM). Writing netcdf3 hangs when writing.

Changes answers

3. Fix `map_overlap` latitude masking silently dropping southern-hemisphere rivers

`generate_ESMF_map_via_xesmf`'s `map_overlap` block normalized latitudes with `normalize_deg` before comparing them to the destination bounding box. That is `mod(x + 360, 360)`, so a latitude of −5 came back as 355, which then compares as *north of* `lat_max` and got masked out.


4. Fix `_get_mesh_bbox` collapsing any domain that touches the 0/360 seam

`_get_mesh_bbox` took `min()`/`max()` of `normalize_deg`'d longitudes, so nodes sitting on exactly lon 360 came back as 0 — which *is* then the minimum while 359.92 is the maximum:

```
mesh spanning 280..360  ->  bbox   0.0000 .. 359.9167   (359.92 deg)
mesh spanning 275..355  ->  bbox 275.0000 .. 355.0000   ( 80.00 deg)
```


`_lon_bbox()` now finds the largest angular gap between successive longitudes and returns the interval outside it, which may wrap (`lon_min > lon_max`). For a fully periodic mesh every gap equals the grid spacing, so the tie falls through to the full range — what a global mesh wants. `_lon_outside()` is the companion membership test, flipping OR to AND for a wrapped interval.


**Cropping the source mesh** did not work quickly so it was dropped 

