### PR TITLE
Fix tarea double-counting a supergrid quadrant

### DIFF
--- a/mom6_forge/grid.py
+++ b/mom6_forge/grid.py
@@ -830,12 +830,14 @@ class Grid:
             dims=["ny", "nx"],
             attrs={"name": "angle q-grid makes with latitude line", "units": "degrees"},
         )
-        # T area
+        # T area: each T-cell spans a 2x2 block of supergrid cells, so its area
+        # is the sum of all four quadrants -- lower-left, lower-right, upper-left
+        # and upper-right.
         self.tarea = xr.DataArray(
             sg.area[::2, ::2]
-            + sg.area[1::2, 1::2]
             + sg.area[::2, 1::2]
-            + sg.area[::2, 1::2],
+            + sg.area[1::2, ::2]
+            + sg.area[1::2, 1::2],
             dims=["ny", "nx"],
             attrs={"name": "area of t-cells", "units": "meters^2"},
         )

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -12,7 +12,7 @@ import xarray as xr
 import pytest
 from mom6_forge.grid import Grid
 from mom6_forge.topo import Topo
-from mom6_forge._supergrid import SupergridBase
+from mom6_forge._supergrid import SupergridBase, _DEFAULT_RADIUS
 from utils import on_cisl_machine
 import os
 
@@ -276,6 +276,45 @@ def test_grid_properties(simple_2by2_grid):
     assert grid._supergrid.lenx == 2.0
     assert grid._supergrid.leny == 2.0
     assert grid.name == "testgrid"
+
+
+def test_grid_tarea_sums_all_four_supergrid_quadrants(get_rect_grid):
+    """Each T-cell area is the sum of its four distinct supergrid quadrants.
+
+    Regression test: the sum used to double-count the upper-left quadrant and
+    omit the lower-right one entirely, so every grid ever built carried a small
+    but systematic area error (~1e-4 relative on a 0.1 deg mid-latitude domain,
+    growing with cell size and latitude).
+    """
+    grid = get_rect_grid
+    sg = grid.supergrid
+    ny, nx = grid.ny, grid.nx
+
+    # Fold the (2*ny, 2*nx) supergrid areas into (ny, 2, nx, 2) and sum the
+    # 2x2 block belonging to each T-cell.
+    expected = sg.area[: 2 * ny, : 2 * nx].reshape(ny, 2, nx, 2).sum(axis=(1, 3))
+    np.testing.assert_allclose(grid.tarea.values, expected, rtol=1e-12)
+
+
+def test_grid_tarea_matches_analytic_spherical_area(get_rect_grid):
+    """Total T-cell area equals the analytic area of the lat/lon box.
+
+    An independent check that does not go through sg.area at all, so a bug in
+    the quadrant bookkeeping cannot hide behind a matching bug in the
+    supergrid cell areas.
+    """
+    grid = get_rect_grid
+    ds = grid.supergrid.to_ds()
+    R = _DEFAULT_RADIUS
+
+    lon_min, lon_max = float(ds.x.min()), float(ds.x.max())
+    lat_min, lat_max = float(ds.y.min()), float(ds.y.max())
+    analytic = (
+        R**2
+        * np.deg2rad(lon_max - lon_min)
+        * (np.sin(np.deg2rad(lat_max)) - np.sin(np.deg2rad(lat_min)))
+    )
+    np.testing.assert_allclose(float(grid.tarea.sum()), analytic, rtol=1e-6)
 
 
 def test_grid_sanitize_name():


### PR DESCRIPTION
## Problem

`Grid.tarea` ([grid.py:834-839](https://github.com/NCAR/mom6_forge/blob/main/mom6_forge/grid.py#L834-L839)) sums:

```python
sg.area[::2, ::2] + sg.area[1::2, 1::2] + sg.area[::2, 1::2] + sg.area[::2, 1::2]
```

`sg.area[::2, 1::2]` appears twice and `sg.area[1::2, ::2]` never appears, so each T-cell's area is three of its four supergrid quadrants with one of them counted twice.

This is wrong on **every** grid, not just exotic ones. On the existing `panama1` fixture (0.1°, 278–282°E, 7–10°N):

- max per-cell relative error **1.58e-04**
- domain total off by **0.014%**

The error scales with cell size and with latitude, because what the duplication misrepresents is the north–south variation in cell area within a T-cell. It is not a rounding artefact — the corrected sum reproduces the block sum to 1.2e-16.

`tarea` is exported as the conservative-regridding weight in `to_esmf_ds()`, so the error propagates into forcing generation rather than staying a diagnostic curiosity.

## Fix

Sum the four distinct quadrants.

## Tests

Two regression tests in `tests/test_grid.py`:

- `test_grid_tarea_sums_all_four_supergrid_quadrants` — compares against the `(ny, 2, nx, 2)` block sum of `sg.area`.
- `test_grid_tarea_matches_analytic_spherical_area` — compares the domain total against the closed-form spherical-box area, which does not go through `sg.area` at all, so a future bug in the supergrid areas cannot hide behind a matching bug in the quadrant bookkeeping.

`tests/test_grid.py tests/test_supergrid.py tests/test_mapping.py tests/test_masks.py tests/test_rotation.py tests/test_utils.py` → 90 passed. The one failure, `test_is_tripolar`, fails identically on `main` (unrelated, `AttributeError: 'Dataset' object ...`).

## Relationship to #113

Independent — #113 touches `_calc_dx_dy` and `get_bounding_boxes`, this touches only the `tarea` sum. Both were surfaced by the same domain-sweep work in CrocoDash; no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)