### PR TITLE
Get mesh grid dims directly in write_esmf_mapping_file

### DIFF
--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -261,11 +261,10 @@ def write_mapping_file(
             weights_coo, coo_matrix
         ), "weights_coo must be a scipy sparse COO matrix"
 
-    # From 1D ESMF mesh to 2D grid
-    from mom6_forge.topo import Topo
-
-    src_topo = Topo.from_esmf_mesh(src_mesh)
-    dst_topo = Topo.from_esmf_mesh(dst_mesh)
+    # Only the (ny, nx) shape of each mesh is needed below - get it directly
+    # from element connectivity, without reconstructing full mesh geometry.
+    src_nx, src_ny = get_mesh_dimensions(src_mesh)
+    dst_nx, dst_ny = get_mesh_dimensions(dst_mesh)
 
     # 1/3: Source Domain Fields
     # -------------------
@@ -332,7 +331,7 @@ def write_mapping_file(
     )
 
     src_grid_dims = xr.DataArray(
-        np.array(src_topo.tmask.shape[::-1]).astype(np.int32),
+        np.array([src_nx, src_ny]).astype(np.int32),
         dims=["src_grid_rank"],
         # attrs={
         #    'long_name': 'dimensions of the source grid',
@@ -340,12 +339,12 @@ def write_mapping_file(
     )
 
     nj_a = xr.DataArray(
-        [i + 1 for i in range(src_topo.tmask.shape[0])],
+        [i + 1 for i in range(src_ny)],
         dims=["nj_a"],
     )
 
     ni_a = xr.DataArray(
-        [i + 1 for i in range(src_topo.tmask.shape[1])],
+        [i + 1 for i in range(src_nx)],
         dims=["ni_a"],
     )
 
@@ -414,7 +413,7 @@ def write_mapping_file(
     )
 
     dst_grid_dims = xr.DataArray(
-        np.array(dst_topo.tmask.shape[::-1]).astype(np.int32),
+        np.array([dst_nx, dst_ny]).astype(np.int32),
         dims=["dst_grid_rank"],
         # dst_grid_dimsattrs={
         #    'long_name': 'dimensions of the destination grid',
@@ -422,12 +421,12 @@ def write_mapping_file(
     )
 
     nj_b = xr.DataArray(
-        [i + 1 for i in range(dst_topo.tmask.shape[0])],
+        [i + 1 for i in range(dst_ny)],
         dims=["nj_b"],
     )
 
     ni_b = xr.DataArray(
-        [i + 1 for i in range(dst_topo.tmask.shape[1])],
+        [i + 1 for i in range(dst_nx)],
         dims=["ni_b"],
     )
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,6 +1,7 @@
 import xarray as xr
 import numpy as np
 import scipy.sparse as sp
+import pytest
 from pathlib import Path
 from mom6_forge.mapping import (
     compute_cressman_weights,
@@ -9,8 +10,10 @@ from mom6_forge.mapping import (
     regrid_dataset_via_cressman,
     _make_subgrid_points,
     regrid_with_subsampling,
+    write_mapping_file,
 )
 from mom6_forge._supergrid import haversine
+from mom6_forge.grid import Grid
 
 
 def make_synthetic_grids():
@@ -356,3 +359,46 @@ def test_regrid_with_subsampling_time_dim(get_simple_grid):
         assert np.allclose(
             ds["data"].values[t], expected_spatial
         ), f"Regridded data at t={t} does not match expected values."
+
+
+# ---------------------------------------------------------------------------
+# write_mapping_file mesh-shape lookup
+# ---------------------------------------------------------------------------
+
+
+def _write_esmf_mesh(grid, path):
+    grid.supergrid.to_esmf_mesh(str(path), mask="all_unmasked")
+    return path
+
+
+def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
+    tmp_path, monkeypatch
+):
+    """write_mapping_file only ever needs each mesh's (nx, ny) shape - it must not
+    reconstruct full mesh geometry (Topo.from_esmf_mesh) just to get that shape."""
+    src_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_shape"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_shape"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("write_mapping_file must not call Topo.from_esmf_mesh")
+
+    monkeypatch.setattr("mom6_forge.topo.Topo.from_esmf_mesh", _boom)
+
+    weights_coo = sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6))
+    out_path = tmp_path / "out.nc"
+    write_mapping_file(
+        src_mesh=str(src_path),
+        dst_mesh=str(dst_path),
+        filename=out_path,
+        weights_coo=weights_coo,
+    )
+
+    ds = xr.open_dataset(out_path)
+    assert list(ds["src_grid_dims"].values) == [3, 2]
+    assert list(ds["dst_grid_dims"].values) == [2, 2]


### PR DESCRIPTION
`write_esmf_mapping_file` only needs each mesh's `(ny, nx)` shape, but was calling `Topo.from_esmf_mesh()` twice to get it — reconstructing full supergrid geometry as a side effect.

Now uses `get_mesh_dimensions()` directly, and `src_grid_dims`/`dst_grid_dims` plus the `ni_*`/`nj_*` index vectors are built from those ints.

`tests/test_mapping.py`: 7 passed.