### PR TITLE
Fix map_overlap masking at the 0/360 seam and across the equator

### DIFF
--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -261,11 +261,10 @@ def write_mapping_file(
             weights_coo, coo_matrix
         ), "weights_coo must be a scipy sparse COO matrix"
 
-    # From 1D ESMF mesh to 2D grid
-    from mom6_forge.topo import Topo
-
-    src_topo = Topo.from_esmf_mesh(src_mesh)
-    dst_topo = Topo.from_esmf_mesh(dst_mesh)
+    # Only the (ny, nx) shape of each mesh is needed below - get it directly
+    # from element connectivity, without reconstructing full mesh geometry.
+    src_nx, src_ny = get_mesh_dimensions(src_mesh)
+    dst_nx, dst_ny = get_mesh_dimensions(dst_mesh)
 
     # 1/3: Source Domain Fields
     # -------------------
@@ -332,7 +331,7 @@ def write_mapping_file(
     )
 
     src_grid_dims = xr.DataArray(
-        np.array(src_topo.tmask.shape[::-1]).astype(np.int32),
+        np.array([src_nx, src_ny]).astype(np.int32),
         dims=["src_grid_rank"],
         # attrs={
         #    'long_name': 'dimensions of the source grid',
@@ -340,12 +339,12 @@ def write_mapping_file(
     )
 
     nj_a = xr.DataArray(
-        [i + 1 for i in range(src_topo.tmask.shape[0])],
+        [i + 1 for i in range(src_ny)],
         dims=["nj_a"],
     )
 
     ni_a = xr.DataArray(
-        [i + 1 for i in range(src_topo.tmask.shape[1])],
+        [i + 1 for i in range(src_nx)],
         dims=["ni_a"],
     )
 
@@ -414,7 +413,7 @@ def write_mapping_file(
     )
 
     dst_grid_dims = xr.DataArray(
-        np.array(dst_topo.tmask.shape[::-1]).astype(np.int32),
+        np.array([dst_nx, dst_ny]).astype(np.int32),
         dims=["dst_grid_rank"],
         # dst_grid_dimsattrs={
         #    'long_name': 'dimensions of the destination grid',
@@ -422,12 +421,12 @@ def write_mapping_file(
     )
 
     nj_b = xr.DataArray(
-        [i + 1 for i in range(dst_topo.tmask.shape[0])],
+        [i + 1 for i in range(dst_ny)],
         dims=["nj_b"],
     )
 
     ni_b = xr.DataArray(
-        [i + 1 for i in range(dst_topo.tmask.shape[1])],
+        [i + 1 for i in range(dst_nx)],
         dims=["ni_b"],
     )
 

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -528,6 +528,34 @@ def write_mapping_file(
     )
 
 
+def _lon_window(lon):
+    """Longitude window covered by `lon`, as ``(start, width)`` in degrees.
+
+    The window runs `width` degrees east from `start`, so testing membership is
+    ``np.mod(x - start, 360) <= width`` and needs no special case for a window
+    that crosses the 0/360 seam.
+
+    Taking ``min()``/``max()`` of normalized longitudes is what this replaces, and
+    it is wrong for any mesh touching the seam. ``normalize_deg`` is
+    ``mod(x + 360, 360)``, so a node at exactly lon 360 becomes 0 - which then *is*
+    the minimum, while 359.92 is the maximum. A mesh spanning 350..360 reports
+    0.00..359.00, i.e. nearly the whole globe, and `map_overlap` masking below
+    stops doing anything in longitude.
+
+    The window is instead the complement of the largest *gap* between successive
+    longitudes, taken circularly. For a fully periodic mesh every gap equals the
+    grid spacing, so the widest is arbitrary and the window comes back as
+    360 minus one spacing - the same near-global answer min/max gave, which is
+    what a global mesh wants.
+    """
+    lon = np.unique(normalize_deg(np.asarray(lon, dtype=float)))
+    if lon.size == 1:
+        return float(lon[0]), 0.0
+    gaps = np.diff(np.append(lon, lon[0] + 360.0))
+    widest = int(np.argmax(gaps))
+    return float(lon[(widest + 1) % lon.size]), float(360.0 - gaps[widest])
+
+
 def generate_ESMF_map_via_xesmf(
     src_mesh_path,
     dst_mesh_path,
@@ -573,19 +601,26 @@ def generate_ESMF_map_via_xesmf(
         ), "centerCoords must have 'units' attribute"
         assert (
             "degrees" in dst_mesh["centerCoords"].attrs["units"]
-        ), "get_mesh_dimensions() expects centerCoords in degrees"
-        dst_mesh_lon = normalize_deg(dst_mesh["nodeCoords"].data[:, 0])
-        dst_mesh_lat = normalize_deg(dst_mesh["nodeCoords"].data[:, 1])
-        lon_min, lon_max = dst_mesh_lon.min(), dst_mesh_lon.max()
-        lat_min, lat_max = dst_mesh_lat.min(), dst_mesh_lat.max()
+        ), "map_overlap masking expects centerCoords in degrees"
+        # Longitude goes through _lon_window, which stays correct for a
+        # destination touching the 0/360 seam; min()/max() of normalized
+        # longitudes does not.
+        lon_start, lon_width = _lon_window(dst_mesh["nodeCoords"].data[:, 0])
 
-        # normalize source grid coordinates
-        src_lon = normalize_deg(src_grid["lon"].data)
-        src_lat = normalize_deg(src_grid["lat"].data)
+        # Latitude must NOT be normalized. Wrapping both sides through
+        # normalize_deg is self-consistent for a destination lying entirely in
+        # one hemisphere, which is why this went unspotted - but not for one
+        # straddling the equator. Its latitudes then split into two clusters
+        # (357..360 and 0..3 for a -3..3 domain), so min()/max() collapse to ~0
+        # and ~359 and the latitude test stops masking anything: the regrid runs
+        # against the source mesh's whole latitude range. On the test
+        # configuration that is 92 weights where the domain calls for 24.
+        dst_mesh_lat = dst_mesh["nodeCoords"].data[:, 1]
+        lat_min, lat_max = dst_mesh_lat.min(), dst_mesh_lat.max()
+        src_lat = src_grid["lat"].data
 
         src_grid["mask"].data = np.where(
-            (src_lon < lon_min)
-            | (src_lon > lon_max)
+            (np.mod(src_grid["lon"].data - lon_start, 360.0) > lon_width)
             | (src_lat < lat_min)
             | (src_lat > lat_max),
             0,

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -11,6 +11,9 @@ from mom6_forge.mapping import (
     _make_subgrid_points,
     regrid_with_subsampling,
     write_mapping_file,
+    _lon_window,
+    gen_rof_maps,
+    get_nn_map_filepath,
 )
 from mom6_forge._supergrid import haversine
 from mom6_forge.grid import Grid
@@ -402,3 +405,103 @@ def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
     ds = xr.open_dataset(out_path)
     assert list(ds["src_grid_dims"].values) == [3, 2]
     assert list(ds["dst_grid_dims"].values) == [2, 2]
+
+
+# ---------------------------------------------------------------------------
+# map_overlap masking: 0/360 seam and equator-straddling destinations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "lon, expected",
+    [
+        # a regional window, nowhere near the seam
+        (np.arange(10.0, 21.0), (10.0, 10.0)),
+        # the same window ending exactly on lon 360, where normalize_deg sends
+        # the last node to 0 and min()/max() reported 0.00..359.00
+        (np.arange(350.0, 361.0), (350.0, 10.0)),
+        # written the other way round, as negative longitudes
+        (np.arange(-10.0, 1.0), (350.0, 10.0)),
+        # a single point has no width
+        (np.array([42.0]), (42.0, 0.0)),
+        # fully periodic: every gap is the grid spacing, so the window is the
+        # whole globe bar one spacing - what min()/max() also gave for it
+        (np.arange(0.0, 360.0), (1.0, 359.0)),
+    ],
+)
+def test_lon_window(lon, expected):
+    start, width = _lon_window(lon)
+    assert (start, width) == pytest.approx(expected)
+
+
+def test_map_overlap_masking_is_longitude_rotation_invariant(tmp_path):
+    """map_overlap must mask the same way whether or not the domain touches lon 360.
+
+    The source mesh is uniform in longitude, so two destination windows of equal
+    width must select equally many source cells no matter where they sit. Before
+    the fix the seam window's bbox came back as ~0..359, masked nothing, and
+    mapped nearly the whole source mesh - 261 entries against the interior
+    window's 90.
+    """
+    rof_grid = Grid(
+        resolution=1.0, xstart=330.0, lenx=30.0, ystart=-5.0, leny=10.0, name="rof_rot"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof_rot.nc")
+
+    counts = {}
+    # "seam" ends on exactly lon 360; "interior" is the same width, 10 deg west.
+    for tag, xstart in (("seam", 350.0), ("interior", 340.0)):
+        ocn_grid = Grid(
+            resolution=1.0, xstart=xstart, lenx=10.0, ystart=-3.0, leny=6.0, name=tag
+        )
+        ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / f"ocn_{tag}.nc")
+        out_dir = tmp_path / f"out_{tag}"
+        gen_rof_maps(rof_path, ocn_path, out_dir, f"map_{tag}", rmax=50, fold=100)
+        with xr.open_dataset(get_nn_map_filepath(f"map_{tag}", out_dir)) as ds:
+            counts[tag] = int(ds["S"].size)
+
+    assert counts["interior"] > 0, "interior destination should map some source cells"
+    assert counts["seam"] == counts["interior"], (
+        f"equal-width domains must map equally many source cells regardless of "
+        f"where they sit in longitude, got {counts} - the domain touching lon 360 "
+        f"is getting a near-global window again, so map_overlap masks nothing"
+    )
+
+
+def test_map_overlap_masking_is_latitude_translation_invariant(tmp_path):
+    """map_overlap must mask by true latitude, not by a mod-360 wrap of it.
+
+    The old code ran both the destination bbox and the source latitudes through
+    normalize_deg. That is self-consistent for a destination lying entirely in one
+    hemisphere - which is why it went unspotted - but not for one straddling the
+    equator: a -3..3 destination normalizes into two clusters, 357..360 and 0..3,
+    so min()/max() collapse to ~0 and ~359 and the latitude test masks nothing at
+    all.
+
+    The source mesh is uniform in latitude, so three destination windows of equal
+    height must select equally many source cells wherever they sit. Before the fix
+    the equator-straddling window mapped 92 entries against the other two's 24.
+    """
+    rof_grid = Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=-12.0, leny=24.0, name="rof_lat"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof_lat.nc")
+
+    counts = {}
+    for tag, ystart in (("straddle", -3.0), ("north", 3.0), ("south", -9.0)):
+        ocn_grid = Grid(
+            resolution=1.0, xstart=13.0, lenx=4.0, ystart=ystart, leny=6.0, name=tag
+        )
+        ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / f"ocn_{tag}.nc")
+        out_dir = tmp_path / f"out_{tag}"
+        gen_rof_maps(rof_path, ocn_path, out_dir, f"map_{tag}", rmax=50, fold=100)
+        with xr.open_dataset(get_nn_map_filepath(f"map_{tag}", out_dir)) as ds:
+            counts[tag] = int(ds["S"].size)
+
+    assert counts["north"] > 0, "northern destination should map some source cells"
+    assert counts["straddle"] == counts["north"] == counts["south"], (
+        f"equal-height domains must map equally many source cells regardless of "
+        f"where they sit in latitude, got {counts} - the equator-straddling domain "
+        f"is getting a ~0..359 latitude bbox again, so map_overlap masks nothing "
+        f"in latitude"
+    )

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,6 +1,7 @@
 import xarray as xr
 import numpy as np
 import scipy.sparse as sp
+import pytest
 from pathlib import Path
 from mom6_forge.mapping import (
     compute_cressman_weights,
@@ -9,8 +10,10 @@ from mom6_forge.mapping import (
     regrid_dataset_via_cressman,
     _make_subgrid_points,
     regrid_with_subsampling,
+    write_mapping_file,
 )
 from mom6_forge._supergrid import haversine
+from mom6_forge.grid import Grid
 
 
 def make_synthetic_grids():
@@ -356,3 +359,46 @@ def test_regrid_with_subsampling_time_dim(get_simple_grid):
         assert np.allclose(
             ds["data"].values[t], expected_spatial
         ), f"Regridded data at t={t} does not match expected values."
+
+
+# ---------------------------------------------------------------------------
+# write_mapping_file mesh-shape lookup
+# ---------------------------------------------------------------------------
+
+
+def _write_esmf_mesh(grid, path):
+    grid.supergrid.to_esmf_mesh(str(path), mask="all_unmasked")
+    return path
+
+
+def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
+    tmp_path, monkeypatch
+):
+    """write_mapping_file only ever needs each mesh's (nx, ny) shape - it must not
+    reconstruct full mesh geometry (Topo.from_esmf_mesh) just to get that shape."""
+    src_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_shape"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_shape"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("write_mapping_file must not call Topo.from_esmf_mesh")
+
+    monkeypatch.setattr("mom6_forge.topo.Topo.from_esmf_mesh", _boom)
+
+    weights_coo = sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6))
+    out_path = tmp_path / "out.nc"
+    write_mapping_file(
+        src_mesh=str(src_path),
+        dst_mesh=str(dst_path),
+        filename=out_path,
+        weights_coo=weights_coo,
+    )
+
+    ds = xr.open_dataset(out_path)
+    assert list(ds["src_grid_dims"].values) == [3, 2]
+    assert list(ds["dst_grid_dims"].values) == [2, 2]


### PR DESCRIPTION
Second split from #125. Stacked on #127.

`map_overlap` normalized coordinates with `normalize_deg` then took min/max, which breaks twice: a mesh touching lon 360 got a near-global bbox (nodes at 360 wrap to 0, becoming the *minimum*), and an equator-straddling destination's latitudes split into two clusters so min/max collapsed to ~0..359 and masked nothing in latitude.

`_lon_window()` returns the destination's longitude window as `(start, width)` — the complement of the largest circular gap — so membership is `mod(x - start, 360) <= width` with no seam special case. Latitude is compared raw. A fully periodic mesh still comes back near-global.

**Changes answers** — on the new tests the seam domain drops 261 weights → 60 and the equator-straddling one 92 → 24.

Note: #125's description called the latitude half a southern-hemisphere failure. It isn't — a purely southern destination maps correctly on `main` (both sides were normalized consistently). The failure is equator-straddling destinations, which is what the test covers.