### PR TITLE
Pad n_s so ESMF_FactorRead's float32 PET split stays valid

### DIFF
--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -194,6 +194,74 @@ def _construct_vertex_coords(mesh):
     return xv_data, yv_data
 
 
+# ESMF_FactorRead.F90 splits the weight list across PETs with
+#
+#     esplit    = floor(real(nElements) / real(petCount))
+#     remainder = nElements - esplit*petCount
+#     lb        = localPet*esplit + remainder + 1
+#
+# where `real` is the default REAL, i.e. float32. Above 2**24 that cannot hold
+# n_s exactly; when it rounds *up*, esplit*petCount overshoots n_s, `remainder`
+# goes negative, and PET 0 hands netCDF a negative start index. The run dies in
+# datainitialize with "ESMF_FactorRead netCDF Status Return Error" (checked
+# against ESMF v8.9.1). It has nothing to do with the file's format - classic,
+# cdf5 and netCDF4 all fail the same way.
+#
+# n_s <= 2**24 is provably safe: the quotient can only round across an integer
+# boundary when |n_s/petCount - m| < ulp/2 for some integer m, and since
+# |n_s - m*petCount| >= 1 that needs n_s > 2**24. Past that, rounding n_s up to a
+# multiple of 1024 keeps it exactly representable in float32 (for n_s < 2**33)
+# and makes n_s divisible by every power-of-two petCount up to 1024, which drives
+# `remainder` to exactly 0.
+#
+# This does NOT cover every petCount - a petCount that does not divide n_s can
+# still round badly (for n_s = 400,669,696, 87 of the first 4096 counts do,
+# including 24 and 30). Power-of-two mediator layouts, which is what CESM uses,
+# are safe. Remove all of this once ESMF does the split in integer arithmetic.
+_ESMF_FACTORREAD_EXACT_MAX = 2**24
+_N_S_ALIGNMENT = 1024
+_N_S_ALIGNMENT_MAX = 2**33
+
+
+def _pad_weights_for_esmf(S, row, col):
+    """Pad the weight list so ESMF_FactorRead's float32 PET split stays valid.
+
+    Appends zero-weight entries that reuse the first real (row, col) pair, so
+    the sparse mat-vec is unchanged and the route handle's set of source and
+    destination cells is exactly what it already was. A pair the map does not
+    otherwise use would pull an extra source cell into the communication
+    pattern, and 0 * NaN would then poison its destination cell.
+
+    ESMF sums duplicate index pairs - verified against esmpy 8.9.1, where an
+    unpadded file, one padded with identical pairs and one padded with distinct
+    pairs all produced bit-identical output.
+    """
+    n_s = S.sizes["n_s"]
+    if n_s <= _ESMF_FACTORREAD_EXACT_MAX or n_s % _N_S_ALIGNMENT == 0:
+        return S, row, col
+    if n_s >= _N_S_ALIGNMENT_MAX:
+        raise ValueError(
+            f"n_s = {n_s:,} is at or above 2**33, where an alignment of "
+            f"{_N_S_ALIGNMENT} no longer guarantees an exact float32 value; "
+            "ESMF_FactorRead's PET split cannot be made safe by padding here."
+        )
+    n_pad = -(-n_s // _N_S_ALIGNMENT) * _N_S_ALIGNMENT - n_s
+    print(
+        f"  padding n_s {n_s:,} -> {n_s + n_pad:,} (+{n_pad} zero-weight entries) "
+        "to keep ESMF_FactorRead's float32 PET split valid"
+    )
+    pad = lambda da, fill: xr.DataArray(
+        np.concatenate([da.data, np.full(n_pad, fill, dtype=da.dtype)]),
+        dims=["n_s"],
+        attrs=da.attrs,
+    )
+    return (
+        pad(S, 0),
+        pad(row, row.data[0]),
+        pad(col, col.data[0]),
+    )
+
+
 def write_mapping_file(
     src_mesh,
     dst_mesh,
@@ -475,9 +543,9 @@ def write_mapping_file(
 
     # Drop NaN values from S, col, and row
     non_nan_indices = np.where(~np.isnan(S))[0]
-    S_new = S[non_nan_indices]
-    row_new = row[non_nan_indices]
-    col_new = col[non_nan_indices]
+    S_new, row_new, col_new = _pad_weights_for_esmf(
+        S[non_nan_indices], row[non_nan_indices], col[non_nan_indices]
+    )
 
     # Create the dataset and write to a netCDF file
     # ------------------------------------------------

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -3,6 +3,7 @@ import numpy as np
 import scipy.sparse as sp
 import pytest
 from pathlib import Path
+from mom6_forge import mapping
 from mom6_forge.mapping import (
     compute_cressman_weights,
     dst_to_source,
@@ -505,3 +506,65 @@ def test_map_overlap_masking_is_latitude_translation_invariant(tmp_path):
         f"is getting a ~0..359 latitude bbox again, so map_overlap masks nothing "
         f"in latitude"
     )
+
+
+# ---------------------------------------------------------------------------
+# ESMF_FactorRead float32 PET-split padding
+# ---------------------------------------------------------------------------
+
+
+def test_pad_weights_for_esmf_is_noop_below_threshold():
+    """Below 2**24 the float32 PET split in ESMF_FactorRead is provably exact,
+    so nothing is added - a small map must come out byte-for-byte as built."""
+    S = xr.DataArray(np.array([0.5, 0.25, 0.25]), dims=["n_s"])
+    row = xr.DataArray(np.array([7, 7, 9], dtype="i4"), dims=["n_s"])
+    col = xr.DataArray(np.array([3, 4, 5], dtype="i4"), dims=["n_s"])
+
+    S2, row2, col2 = mapping._pad_weights_for_esmf(S, row, col)
+
+    assert S2.sizes["n_s"] == 3
+    assert np.array_equal(S2.values, S.values)
+    assert np.array_equal(row2.values, row.values)
+    assert np.array_equal(col2.values, col.values)
+
+
+def test_pad_weights_for_esmf_aligns_and_stays_inert(monkeypatch):
+    """Above the threshold n_s is rounded up to a multiple of 1024 with
+    zero-weight entries that reuse the first real (row, col) pair.
+
+    Reusing an existing pair matters: a pair the map does not otherwise use
+    would pull an extra source cell into the route handle, and 0 * NaN would
+    then poison its destination cell. ESMF sums duplicate index pairs.
+    """
+    monkeypatch.setattr(mapping, "_ESMF_FACTORREAD_EXACT_MAX", 4)
+    n = 1500
+    S = xr.DataArray(np.linspace(0.1, 0.9, n), dims=["n_s"])
+    row = xr.DataArray(np.arange(1, n + 1, dtype="i4"), dims=["n_s"])
+    col = xr.DataArray(np.arange(101, 101 + n, dtype="i4"), dims=["n_s"])
+
+    S2, row2, col2 = mapping._pad_weights_for_esmf(S, row, col)
+
+    assert S2.sizes["n_s"] == 2048
+    assert S2.sizes["n_s"] % mapping._N_S_ALIGNMENT == 0
+    # the real weights are untouched, and the pad contributes nothing
+    assert np.array_equal(S2.values[:n], S.values)
+    assert (S2.values[n:] == 0).all()
+    assert S2.values.sum() == pytest.approx(S.values.sum())
+    # the pad introduces no source or destination cell the map didn't already use
+    assert (row2.values[n:] == row.values[0]).all()
+    assert (col2.values[n:] == col.values[0]).all()
+    assert set(np.unique(row2.values)) == set(np.unique(row.values))
+    assert set(np.unique(col2.values)) == set(np.unique(col.values))
+    assert row2.dtype == row.dtype and col2.dtype == col.dtype
+
+
+def test_pad_weights_for_esmf_rejects_unfixable_size(monkeypatch):
+    """Past 2**33 a 1024 alignment no longer lands on an exact float32 value, so
+    padding cannot make the split safe - fail loudly rather than pretend."""
+    monkeypatch.setattr(mapping, "_ESMF_FACTORREAD_EXACT_MAX", 4)
+
+    class _Fake:
+        sizes = {"n_s": 2**33 + 7}
+
+    with pytest.raises(ValueError, match=r"2\*\*33"):
+        mapping._pad_weights_for_esmf(_Fake(), None, None)


### PR DESCRIPTION
Third split from #125. Stacked on #128.

`ESMF_FactorRead.F90` splits the weight list across PETs in default REAL — `esplit = floor(real(n_s)/real(petCount))`. Above 2\*\*24 float32 can't hold `n_s` exactly; when the quotient rounds up, `remainder` goes negative and PET 0 hands netCDF a negative start index, killing the run in datainitialize (ESMF v8.9.1). Independent of file format.

`_pad_weights_for_esmf()` rounds `n_s` up to a multiple of 1024 with zero-weight entries reusing the first real `(row, col)` pair — exact in float32, `remainder == 0` for every power-of-two petCount, and no new cell enters the route handle. No-op below 2\*\*24; raises above 2\*\*33.

Doesn't change answers: the pad contributes zero to the mat-vec (ESMF sums duplicate index pairs, verified against esmpy 8.9.1).