### PR TITLE
Write mapping files as compressed netCDF4, optionally single precision

### DIFF
--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -194,6 +194,81 @@ def _construct_vertex_coords(mesh):
     return xv_data, yv_data
 
 
+# Mapping files go out as NETCDF4 with deflate compression. That is a
+# deliberate departure from the NETCDF3_64BIT that CESM mapping files have
+# traditionally used, and it rests on how the file is actually consumed: CMEPS
+# calls ESMF_FieldSMMStore(fldsrc, flddst, mapfile, ...) (med_map_mod.F90),
+# which dispatches to ESMF_FieldSMMStoreFromFile -> ESMF_FactorRead, and
+# ESMF_FactorRead.F90 reads "row", "col" and "S" through plain nf90_get_var
+# calls with no format check anywhere in the path. libnetcdf resolves the
+# format for it, so a compressed netCDF4 file reads identically.
+#
+# Verified in a live CESM run rather than by reading source alone: a full
+# factorial of format (NETCDF3_64BIT_OFFSET / cdf5 / netCDF4 / netCDF4+deflate)
+# x index dtype (int32 / int64) x _FillValue (present / suppressed) was run
+# through the same regional case, and all six variants produced bit-identical
+# mediator history output across 159 fields, including the two mapped runoff
+# fields. Compression is therefore free, and it is worth a great deal: on a
+# global GLOFAS source mesh (n_a = 21,600,000) an Indo-Pacific map at rmax=100
+# goes from 25.85 GiB to 0.72 GiB, a 36x reduction.
+#
+# Level 4 is the knee of the curve on this data - most of what level 9 gets, at
+# a fraction of the write cost - and there is no point chunking arrays smaller
+# than a chunk.
+_DEFLATE_LEVEL = 4
+_DEFLATE_MIN_SIZE = 4096
+
+
+def _write_map_netcdf(ds, filename, single_precision=False):
+    """Write a mapping-file dataset out as compressed netCDF4.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The mapping-file dataset to write.
+    filename : str or Path
+        Path to the output mapping file.
+    single_precision : bool, optional
+        If True, write every 64-bit float variable as 32-bit, halving the size of
+        the dominant variables. netCDF converts on read, and ESMF_FactorRead
+        reads S into a real(ESMF_KIND_R8) buffer regardless of the on-disk type,
+        so a single-precision file is still a valid ESMF weight file. It is also
+        where most of the compression comes from: rounding to float32 collapses
+        the number of distinct weight values by roughly 19x, which is what lets
+        deflate dedupe S from 4.4x down to 21.6x.
+    """
+
+    filename = Path(filename)
+
+    # Nothing here needs 64-bit indices, and int32 halves the two largest
+    # integer arrays (row and col are both length n_s). _FillValue is suppressed
+    # because these are dense arrays with no missing entries - a fill attribute
+    # on them is noise that some readers would otherwise turn into NaNs.
+    encoding = {}
+    for var in ds.variables:
+        enc = {"_FillValue": None}
+        dtype = ds[var].dtype
+        if np.issubdtype(dtype, np.integer) and dtype != np.int32:
+            enc["dtype"] = "int32"
+        elif (
+            single_precision
+            and np.issubdtype(dtype, np.floating)
+            and dtype != np.float32
+        ):
+            enc["dtype"] = "float32"
+        # Only worth it on the arrays that dominate; the grid-dims and ni/nj
+        # index arrays are too small for chunking overhead to pay off. mask/frac
+        # are near-constant and compress by well over an order of magnitude; the
+        # coordinate and weight arrays are smooth enough to give back a useful
+        # fraction too.
+        if ds[var].size >= _DEFLATE_MIN_SIZE:
+            enc["zlib"] = True
+            enc["complevel"] = _DEFLATE_LEVEL
+        encoding[var] = enc
+
+    ds.to_netcdf(filename, format="NETCDF4", encoding=encoding)
+
+
 # ESMF_FactorRead.F90 splits the weight list across PETs with
 #
 #     esplit    = floor(real(nElements) / real(petCount))
@@ -270,6 +345,7 @@ def write_mapping_file(
     weights_esmpy=None,
     weights_coo=None,
     area_normalization=False,
+    single_precision=False,
 ):
     """Based on a given source mesh, destination mesh, and weights, write out an ESMF map file.
 
@@ -291,6 +367,9 @@ def write_mapping_file(
         Regridding method, by default 'bilinear'.
     area_normalization : bool, optional
         Whether to multiply the weights by (area_source / area_destination), by default False.
+    single_precision : bool, optional
+        If True, write 64-bit float variables as 32-bit, halving their on-disk
+        size.
 
     Returns
     -------
@@ -589,11 +668,7 @@ def write_mapping_file(
     if dst_mesh_path := dst_mesh.encoding.get("source"):
         ds.attrs["domain_b"] = dst_mesh_path
 
-    ds.to_netcdf(
-        filename,
-        format="NETCDF3_64BIT",
-        encoding={var: {"_FillValue": None} for var in ds.data_vars},
-    )
+    _write_map_netcdf(ds, filename, single_precision)
 
 
 def _lon_window(lon):
@@ -631,6 +706,7 @@ def generate_ESMF_map_via_xesmf(
     method,
     area_normalization=False,
     map_overlap=True,
+    single_precision=False,
 ):
     """Generate an ESMF mapping file using xesmf.
 
@@ -649,6 +725,8 @@ def generate_ESMF_map_via_xesmf(
     map_overlap : bool
         If True, only map the overlapping area between the source and destination meshes, i.e.,
         zero out the mask in the source mesh that falls outside the rectangle defined by the destination mesh.
+    single_precision : bool, optional
+        Write 64-bit float variables as 32-bit. See `write_mapping_file`.
     """
 
     src_grid = grid_from_esmf_mesh(src_mesh_path)
@@ -719,6 +797,7 @@ def generate_ESMF_map_via_xesmf(
         weights=regridder.weights,
         filename=mapping_file,
         area_normalization=area_normalization,
+        single_precision=single_precision,
     )
 
 
@@ -937,7 +1016,13 @@ def get_smoothed_map_filepath(mapping_file_prefix, output_dir, rmax, fold):
 
 
 def gen_rof_maps(
-    rof_mesh_path, ocn_mesh_path, output_dir, mapping_file_prefix, rmax=None, fold=None
+    rof_mesh_path,
+    ocn_mesh_path,
+    output_dir,
+    mapping_file_prefix,
+    rmax=None,
+    fold=None,
+    single_precision=True,
 ):
     """Generate (1) nearest neighbor and (2) smoothed nearest neighbor mapping files
     from a runoff mesh to an ocean mesh.
@@ -957,6 +1042,12 @@ def gen_rof_maps(
         Maximum distance for smoothing weights, in kilometers. If None, no smoothing is applied.
     fold : float, optional
         Fold factor (km) determining the strength of smoothing based on distance. If None, no smoothing is applied.
+    single_precision : bool, optional
+        If True (the default), write 64-bit float variables as 32-bit, halving
+        their on-disk size. netCDF converts on read and ESMF_FactorRead reads S
+        into a real(R8) buffer regardless of the on-disk type, so this stays a
+        valid ESMF weight file. It is also what makes the deflate pass effective
+        - see the note above `_write_map_netcdf`.
     """
 
     print(f"Generating nearest neighbor mapping file...")
@@ -986,6 +1077,7 @@ def gen_rof_maps(
         mapping_file=nn_map_filepath,
         method="nearest_d2s",
         area_normalization=True,
+        single_precision=single_precision,
     )
 
     print(f"  Generated nearest mapping file in {(t1:=time()) - t0:.2f} seconds at:")
@@ -1047,6 +1139,7 @@ def gen_rof_maps(
             filename=nnsm_map_filepath,
             weights_coo=S_smooth,
             area_normalization=False,  # No area normalization for smoothing
+            single_precision=single_precision,
         )
 
         print(f"  Generated smoothed mapping file in {time() - t1:.2f} seconds at:")

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,5 +1,6 @@
 import xarray as xr
 import numpy as np
+import netCDF4
 import scipy.sparse as sp
 import pytest
 from pathlib import Path
@@ -16,6 +17,7 @@ from mom6_forge.mapping import (
     _construct_vertex_coords,
     gen_rof_maps,
     get_nn_map_filepath,
+    get_smoothed_map_filepath,
 )
 from mom6_forge._supergrid import haversine
 from mom6_forge.grid import Grid
@@ -666,3 +668,163 @@ def test_construct_vertex_coords_matches_loop_on_real_mesh(tmp_path):
     assert xv.shape == (16, 4)
     assert np.array_equal(xv, xv_ref)
     assert np.array_equal(yv, yv_ref)
+
+
+# ---------------------------------------------------------------------------
+# Compressed netCDF4 mapping-file writes
+# ---------------------------------------------------------------------------
+
+
+def _small_map(tmp_path, filename, **kwargs):
+    """Write a mapping file from a tiny 3x2 source and 2x2 destination mesh."""
+    src_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=3.0, ystart=0.0, leny=2.0, name="src_fmt"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_fmt"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+
+    out_path = tmp_path / filename
+    write_mapping_file(
+        src_mesh=str(src_path),
+        dst_mesh=str(dst_path),
+        filename=out_path,
+        weights_coo=sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6)),
+        **kwargs,
+    )
+    return out_path
+
+
+def test_write_mapping_file_writes_netcdf4_without_fill_values(tmp_path):
+    """Mapping files go out as NETCDF4 rather than the traditional NETCDF3_64BIT.
+    ESMF reads "row"/"col"/"S" through plain nf90_get_var with no format check
+    anywhere in the path, so libnetcdf resolves the format and a netCDF4 file
+    reads identically - verified in a live CESM run over a full factorial of
+    format x index dtype x _FillValue, all bit-identical across 159 mediator
+    fields. _FillValue is suppressed: these are dense arrays with no missing
+    entries, and a fill attribute on them is noise some readers turn into NaNs."""
+    out_path = _small_map(tmp_path, "out.nc")
+
+    nc = netCDF4.Dataset(out_path)
+    try:
+        assert nc.data_model == "NETCDF4"
+        for name, var in nc.variables.items():
+            assert "_FillValue" not in var.ncattrs(), name
+    finally:
+        nc.close()
+
+
+def test_write_mapping_file_downcasts_every_integer(tmp_path):
+    """Every integer variable comes out as int32, coordinate or not. `nj_a`/
+    `ni_a`/`nj_b`/`ni_b` are coordinate variables (their DataArray name matches
+    their sole dimension), so an encoding loop scoped to `ds.data_vars` silently
+    skips them and leaves them as int64 - which is how this was found. Nothing in
+    a mapping file needs 64-bit indices, and int32 halves `row` and `col`, the
+    two largest integer arrays."""
+    out_path = _small_map(tmp_path, "out.nc")
+
+    nc = netCDF4.Dataset(out_path)
+    try:
+        for name, var in nc.variables.items():
+            if np.issubdtype(var.dtype, np.integer):
+                assert var.dtype == np.int32, f"{name} is {var.dtype}, expected int32"
+    finally:
+        nc.close()
+
+
+def test_write_mapping_file_deflates_large_vars_only(tmp_path):
+    """Deflate is applied to the arrays big enough for it to pay off, and skipped
+    on the handful of tiny index/grid-dims arrays where chunking is pure
+    overhead."""
+    src_grid = Grid(
+        resolution=0.5, xstart=0.0, lenx=40.0, ystart=0.0, leny=40.0, name="src_defl"
+    )
+    dst_grid = Grid(
+        resolution=1.0, xstart=0.0, lenx=2.0, ystart=0.0, leny=2.0, name="dst_defl"
+    )
+    src_path = _write_esmf_mesh(src_grid, tmp_path / "src.nc")
+    dst_path = _write_esmf_mesh(dst_grid, tmp_path / "dst.nc")
+
+    write_mapping_file(
+        src_mesh=str(src_path),
+        dst_mesh=str(dst_path),
+        filename=tmp_path / "out.nc",
+        weights_coo=sp.coo_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(4, 6400)),
+    )
+
+    nc = netCDF4.Dataset(tmp_path / "out.nc")
+    try:
+        # src side is 80x80 = 6400 elements, over the deflate threshold
+        assert nc.variables["xc_a"].filters()["zlib"] is True
+        assert nc.variables["mask_a"].filters()["zlib"] is True
+        # dst side is 2x2 and the grid-dims arrays are length 2 - far below it
+        assert nc.variables["dst_grid_dims"].filters()["zlib"] is False
+        assert nc.variables["xc_b"].filters()["zlib"] is False
+    finally:
+        nc.close()
+
+
+def test_write_mapping_file_single_precision(tmp_path):
+    """single_precision halves every float variable's on-disk width and leaves the
+    integer indices alone. A float32 S is still a valid ESMF weight file:
+    ESMF_FactorRead reads it into a real(R8) buffer and netCDF converts on read.
+    It is also what makes deflate effective, by collapsing the number of distinct
+    weight values."""
+    dtypes = {}
+    for tag, single in (("f8", False), ("f4", True)):
+        out_dir = tmp_path / tag
+        out_dir.mkdir()
+        out_path = _small_map(out_dir, "out.nc", single_precision=single)
+        nc = netCDF4.Dataset(out_path)
+        try:
+            dtypes[tag] = {n: v.dtype for n, v in nc.variables.items()}
+            assert nc.variables["S"].dtype == (np.float32 if single else np.float64)
+        finally:
+            nc.close()
+
+    assert dtypes["f8"].keys() == dtypes["f4"].keys()
+    floats = [n for n, d in dtypes["f8"].items() if np.issubdtype(d, np.floating)]
+    assert floats, "expected some float variables to downcast"
+    for name, dtype in dtypes["f4"].items():
+        if name in floats:
+            assert dtype == np.float32, f"{name} is {dtype}, expected float32"
+        else:
+            assert dtype == dtypes["f8"][name] == np.int32, name
+
+
+def test_gen_rof_maps_defaults_to_single_precision(tmp_path):
+    """gen_rof_maps writes single precision by default - the production runoff
+    maps are where the size matters. The variable set is unchanged either way, so
+    a map still describes its own grids."""
+    rof_grid = Grid(
+        resolution=1.0, xstart=10.0, lenx=10.0, ystart=25.0, leny=10.0, name="rof_sp"
+    )
+    ocn_grid = Grid(
+        resolution=1.0, xstart=13.0, lenx=3.0, ystart=28.0, leny=3.0, name="ocn_sp"
+    )
+    rof_path = _write_esmf_mesh(rof_grid, tmp_path / "rof.nc")
+    ocn_path = _write_esmf_mesh(ocn_grid, tmp_path / "ocn.nc")
+
+    out_dir = tmp_path / "out"
+    gen_rof_maps(rof_path, ocn_path, out_dir, "m", rmax=50, fold=100)
+
+    for path in (
+        get_nn_map_filepath("m", out_dir),
+        get_smoothed_map_filepath("m", out_dir, 50, 100),
+    ):
+        nc = netCDF4.Dataset(path)
+        try:
+            assert nc.data_model == "NETCDF4", path.name
+            assert nc.variables["S"].dtype == np.float32, path.name
+            assert nc.variables["row"].dtype == np.int32, path.name
+            # the descriptive geometry is still there - deflate makes it nearly free
+            assert {"xc_a", "yc_a", "mask_a", "area_a", "src_grid_dims"}.issubset(
+                nc.variables
+            )
+            assert {"xc_b", "yc_b", "mask_b", "area_b", "dst_grid_dims"}.issubset(
+                nc.variables
+            )
+        finally:
+            nc.close()


### PR DESCRIPTION
Last split from #125. Stacked on #130.

Nothing in the read path requires NETCDF3_64BIT: `ESMF_FactorRead.F90` reads `row`/`col`/`S` with plain `nf90_get_var` and no format check, so libnetcdf resolves the format. Confirmed in a live CESM run — a factorial of format x index dtype x `_FillValue` gave bit-identical mediator output across 159 fields.

Writes are now NETCDF4 + deflate 4 (arrays ≥ 4096 elements), int32 indices, no `_FillValue`. `single_precision` downcasts float64 → float32 (`ESMF_FactorRead` reads S into a real(R8) buffer regardless) and `gen_rof_maps` defaults it on, since it is also what makes deflate effective.

**3.8x smaller** on a synthetic 1.6M-weight map with random, incompressible weights; on real weights a global GLOFAS map at rmax=100 went 25.85 GiB → 0.72 GiB. Variable set unchanged — dropping source geometry saved only ~1.3% after deflate.

Not carried over from #125: the `gen_rof_maps` change reading mesh dims from the meshes instead of the nn map's `ni_a`/`nj_a`. It only mattered for the minimal-variable-set experiment, which was dropped.