### PR TITLE
Fix rounding error in nx/ny calculation 

### DIFF
--- a/mom6_forge/grid.py
+++ b/mom6_forge/grid.py
@@ -113,8 +113,8 @@ class Grid:
             assert (
                 resolution is not None
             ), "resolution must be provided if nx and ny are not"
-            nx = int(lenx / resolution)
-            ny = int(leny / resolution)
+            nx = int(round(lenx / resolution))
+            ny = int(round(leny / resolution))
 
         if type == "rectilinear_cartesian" and resolution is None:
             raise ValueError(


### PR DESCRIPTION
Closes #135 

Simple fix to ensure that if length / resolution has been carefully chosen by the user, but evaluates to something like 151.99999999 as a float, that nx ends up being 152 rather than 151 (current behaviour)