### PR TITLE
Coastline-masked, topography-aware runoff smoothing, and performance improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,18 @@ jobs:
         run: |
           git config --global user.email "runner@example.com"
           git config --global user.name "CI Runner"
+
+      # CESM input data (ESMF meshes) used by the mapping integration tests.
+      # ~28 MB, fetched once and reused; the key changes only when the file
+      # manifest in tests/utils.py does.
+      - name: Cache CESM input data
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/mom6_forge/inputdata
+          key: cesm-inputdata-${{ hashFiles('tests/utils.py') }}
+          restore-keys: |
+            cesm-inputdata-
+
       - name: Run pytest
         shell: bash -l {0}
         run: |

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -11,6 +11,8 @@ from scipy.spatial import cKDTree
 from scipy.sparse import csc_matrix, coo_matrix, csr_matrix
 import xesmf as xe
 import cf_xarray
+from collections import deque
+from math import sqrt as _sqrt
 
 MPI = None
 rank = lambda: MPI.COMM_WORLD.Get_rank() if MPI else 0
@@ -74,6 +76,29 @@ def grid_from_esmf_mesh(mesh: xr.Dataset | str | Path) -> "Grid":
     )
 
     return ds
+
+
+def flatten_to_mesh(field_2d):
+    """Flatten a 2D horizontal grid field back to a 1D ESMF mesh array.
+
+    This is the exact inverse of the reshape applied in func:`grid_from_esmf_mesh`:
+    both use row-major (C) order, so element indices are preserved.
+
+    Parameters
+    ----------
+    field_2d : np.ndarray or xr.DataArray
+        2D array with dimensions ``(nlat, nlon)`` representing any grid
+        quantity (mask, lon, lat, a custom field, etc.).
+
+    Returns
+    -------
+    field_1d : np.ndarray
+        1D array whose length equals ``nlat * nlon``, with values in the
+        same element ordering as the original ESMF mesh arrays.
+    """
+    if isinstance(field_2d, xr.DataArray):
+        field_2d = field_2d.data
+    return field_2d.reshape(-1, order="C")
 
 
 def extract_coastline_mask(horiz_grid):
@@ -173,25 +198,50 @@ def _construct_vertex_coords(mesh):
         The vertex coordinates in the y-direction.
     """
 
-    xv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
-    yv_data = np.full((len(mesh.centerCoords.data), 4), np.nan)
-
     element_conn = mesh.elementConn.data - 1  # one-based to zero-based indexing
     node_coords = mesh.nodeCoords.data
 
-    for e, nodes in enumerate(element_conn):
-        if np.isnan(nodes[3]):
-            valid_nodes = nodes[:3][~np.isnan(nodes[:3])].astype(int)
-            xv_data[e, :3] = node_coords[valid_nodes, 0]
-            xv_data[e, 3] = xv_data[e, 2]
-            yv_data[e, :3] = node_coords[valid_nodes, 1]
-            yv_data[e, 3] = yv_data[e, 2]
-        else:
-            valid_nodes = nodes.astype(int)
-            xv_data[e, :] = node_coords[valid_nodes, 0]
-            yv_data[e, :] = node_coords[valid_nodes, 1]
+    if np.issubdtype(element_conn.dtype, np.floating):
+        is_tri = np.isnan(element_conn[:, 3])
+    else:
+        is_tri = np.zeros(len(element_conn), dtype=bool)
+
+    conn = element_conn.copy()
+    conn[is_tri, 3] = conn[is_tri, 2]
+    conn = conn.astype(np.intp)
+
+    xv_data = node_coords[conn, 0]
+    yv_data = node_coords[conn, 1]
 
     return xv_data, yv_data
+
+
+# Cell areas, keyed by the mesh file they were computed from.
+# Only the areas are cached, not the vertex coordinates they derive from.
+# Those are eight times larger and, since _construct_vertex_coords is
+# vectorized, cheap to rebuild. Bounded to the two meshes in play.
+_CELL_AREA_CACHE = {}
+_CELL_AREA_CACHE_SIZE = 2
+
+
+def _cached_cell_areas(mesh, xv_data, yv_data):
+    """Return cell areas for a mesh, reusing a cached result when the same
+    mesh file has already been processed.
+
+    The returned array is shared with previous callers and must not be
+    modified. Only pass vertex coordinates derived from ``mesh`` itself.
+    """
+    source = mesh.encoding.get("source") if isinstance(mesh, xr.Dataset) else None
+    if source is not None and source in _CELL_AREA_CACHE:
+        return _CELL_AREA_CACHE[source]
+
+    areas = cell_area_rad(xv_data, yv_data)
+
+    if source is not None:
+        while len(_CELL_AREA_CACHE) >= _CELL_AREA_CACHE_SIZE:
+            _CELL_AREA_CACHE.pop(next(iter(_CELL_AREA_CACHE)))
+        _CELL_AREA_CACHE[source] = areas
+    return areas
 
 
 def write_mapping_file(
@@ -288,6 +338,7 @@ def write_mapping_file(
     )
 
     xv_a_data, yv_a_data = _construct_vertex_coords(src_mesh)
+    area_a_data = _cached_cell_areas(src_mesh, xv_a_data, yv_a_data)
 
     xv_a = xr.DataArray(
         xv_a_data,
@@ -316,7 +367,7 @@ def write_mapping_file(
     )
 
     area_a = xr.DataArray(
-        cell_area_rad(xv_a, yv_a),
+        area_a_data,
         dims=["n_a"],
         attrs={"long_name": "area of cell (input)", "units": "radians^2"},
     )
@@ -370,6 +421,7 @@ def write_mapping_file(
     )
 
     xv_b_data, yv_b_data = _construct_vertex_coords(dst_mesh)
+    area_b_data = _cached_cell_areas(dst_mesh, xv_b_data, yv_b_data)
 
     xv_b = xr.DataArray(
         xv_b_data,
@@ -398,7 +450,7 @@ def write_mapping_file(
     )
 
     area_b = xr.DataArray(
-        cell_area_rad(xv_b, yv_b),
+        area_b_data,
         dims=["n_b"],
         attrs={"long_name": "area of cell (output)", "units": "radians^2"},
     )
@@ -447,7 +499,11 @@ def write_mapping_file(
         row_data = weights_coo.row + 1
 
     if area_normalization:
-        w.data *= area_a.data[col_data - 1] / area_b.data[row_data - 1]
+        area_scale = area_a.data[col_data - 1] / area_b.data[row_data - 1]
+        if hasattr(w, "data"):
+            w.data *= area_scale
+        else:
+            w *= area_scale
 
     S = xr.DataArray(
         w.data,
@@ -523,7 +579,7 @@ def write_mapping_file(
 
     ds.to_netcdf(
         filename,
-        format="NETCDF3_64BIT",
+        format="NETCDF4_CLASSIC",
         encoding={var: {"_FillValue": None} for var in ds.data_vars},
     )
 
@@ -535,6 +591,7 @@ def generate_ESMF_map_via_xesmf(
     method,
     area_normalization=False,
     map_overlap=True,
+    coastline_masking=False,
 ):
     """Generate an ESMF mapping file using xesmf.
 
@@ -553,10 +610,19 @@ def generate_ESMF_map_via_xesmf(
     map_overlap : bool
         If True, only map the overlapping area between the source and destination meshes, i.e.,
         zero out the mask in the source mesh that falls outside the rectangle defined by the destination mesh.
+    coastline_masking : bool
+        If True, apply coastline masking to the destination mesh.
     """
 
     src_grid = grid_from_esmf_mesh(src_mesh_path)
     dst_grid = grid_from_esmf_mesh(dst_mesh_path)
+
+    # update the mask to cover only the coastline area for better nearest neighbor mapping results:
+    if coastline_masking:
+        coastline_mask = extract_coastline_mask(dst_grid)
+        dst_grid["mask"].data = np.where(
+            coastline_mask.data == 1, dst_grid["mask"].data, 0
+        )
 
     # from dst mesh, find the lower left corner and upper right corner
     # then, in the src mesh, zero out the mask falling outside of this rectangle
@@ -709,7 +775,9 @@ def generate_ESMF_map_via_esmpy(
     )
 
 
-def compute_smoothing_weights(mesh_ds, rmax, fold=1.0, xv_data=None, yv_data=None):
+def compute_smoothing_weights(
+    mesh_ds, rmax, fold=1.0, xv_data=None, yv_data=None, coastline_masking=False
+):
     """Compute smoothing weights for a given mesh dataset, using a radius in kilometers.
 
     Parameters
@@ -724,21 +792,30 @@ def compute_smoothing_weights(mesh_ds, rmax, fold=1.0, xv_data=None, yv_data=Non
         The x-coordinates of the vertices. If not provided, they will be computed from the mesh dataset.
     yv_data : np.ndarray, optional
         The y-coordinates of the vertices. If not provided, they will be computed from the mesh dataset.
+    coastline_masking : bool, optional
+        If True, apply smoothing only to the cells adjacent to the coastline.
 
     Returns
     -------
-    weights : scipy.sparse.coo_matrix
-        The computed smoothing weights in coordinate (COO) format.
+    weights : scipy.sparse.csr_matrix
+        The computed smoothing weights in compressed sparse row (CSR) format.
     """
 
     if not isinstance(mesh_ds, xr.Dataset):
         raise ValueError("mesh_ds must be an xarray Dataset.")
+    if rmax <= 0:
+        raise ValueError("rmax must be > 0 km.")
+    if fold <= 0:
+        raise ValueError("fold must be > 0 km.")
 
     # Extract coordinates and mask
     coords = mesh_ds["centerCoords"].values
     if xv_data is None or yv_data is None:
         xv_data, yv_data = _construct_vertex_coords(mesh_ds)
-    areas = cell_area_rad(xv_data, yv_data)
+        areas = _cached_cell_areas(mesh_ds, xv_data, yv_data)
+    else:
+        # Caller-supplied vertices may not match the mesh file; don't cache.
+        areas = cell_area_rad(xv_data, yv_data)
     mask = mesh_ds["elementMask"].values
     mask_bool = mask != 0
 
@@ -755,31 +832,175 @@ def compute_smoothing_weights(mesh_ds, rmax, fold=1.0, xv_data=None, yv_data=Non
     z = R_earth * np.sin(lat)
     xyz = np.stack([x, y, z], axis=1)
 
-    # Build KDTree in 3D Cartesian space
-    tree = cKDTree(xyz)
-    indices = tree.query_ball_tree(tree, rmax)
-
     row_indices, col_indices, data = [], [], []
 
-    for i, neighbors in enumerate(indices):
-        if not mask_bool[i]:
+    grid = grid_from_esmf_mesh(mesh_ds)
+    coastline_mask_bool = None
+    if coastline_masking:
+        coastline_mask = extract_coastline_mask(grid)
+        coastline_mask_bool = flatten_to_mesh(coastline_mask == 1).astype(bool)
+
+    dst_is_cyclic_x = is_mesh_cyclic_x(mesh_ds)
+    nx = grid.sizes["nlon"]
+
+    # index of the cell to the left of cell i:
+    left = np.arange(len(coords)) - 1
+    row_starts = np.arange(0, len(coords), nx)
+    if dst_is_cyclic_x:
+        left[row_starts] = row_starts + nx - 1  # wrap within each row
+    else:
+        left[row_starts] = -1  # mark out-of-bounds at row boundaries
+
+    # index of the cell to the right of cell i:
+    right = np.arange(len(coords)) + 1
+    row_ends = np.arange(nx - 1, len(coords), nx)
+    if dst_is_cyclic_x:
+        right[row_ends] = row_ends - nx + 1  # wrap within each row
+    else:
+        right[row_ends] = -1  # mark out-of-bounds at row boundaries
+
+    # index of the cell above cell i:
+    top = np.arange(len(coords)) - nx
+    top[top < 0] = -1  # mark out-of-bounds indices with -1
+
+    # index of the cell below cell i:
+    bottom = np.arange(len(coords)) + nx
+    bottom[bottom >= len(coords)] = -1  # mark out-of-bounds indices with -1
+
+    # Diagonal neighbors (composed from cardinal neighbors)
+    n_cells = len(coords)
+    top_left = np.full(n_cells, -1, dtype=np.int64)
+    top_right = np.full(n_cells, -1, dtype=np.int64)
+    bot_left = np.full(n_cells, -1, dtype=np.int64)
+    bot_right = np.full(n_cells, -1, dtype=np.int64)
+    has_top = top != -1
+    has_bot = bottom != -1
+    top_left[has_top] = left[top[has_top]]
+    top_right[has_top] = right[top[has_top]]
+    bot_left[has_bot] = left[bottom[has_bot]]
+    bot_right[has_bot] = right[bottom[has_bot]]
+
+    # Precompute CSR adjacency structure (8-connectivity).
+    # Equivalent to appending each cell's non-(-1) neighbors in the order
+    # (left, right, top, bottom, top_left, top_right, bot_left, bot_right),
+    # but built with numpy rather than a per-cell Python loop.
+    all_neighbors = np.stack(
+        [left, right, top, bottom, top_left, top_right, bot_left, bot_right],
+        axis=1,
+    )
+    valid = all_neighbors != -1
+    adj_offset = np.zeros(n_cells + 1, dtype=np.int64)
+    adj_offset[1:] = np.cumsum(valid.sum(axis=1))
+    adj_flat = all_neighbors[valid].astype(np.int64)
+
+    # Convert inner-loop arrays to Python lists for fast scalar access
+    # (avoids numpy scalar overhead on indexing, hashing, and comparison)
+    xyz_x = xyz[:, 0].tolist()
+    xyz_y = xyz[:, 1].tolist()
+    xyz_z = xyz[:, 2].tolist()
+    adj_flat = adj_flat.tolist()
+    adj_offset = adj_offset.tolist()
+    mask_list = mask_bool.tolist()
+
+    two_R = 2 * R_earth
+    sqrt = _sqrt
+
+    # Precompute chord-distance threshold for crow's-fly BFS cutoff
+    chord_rmax_sq = (two_R * np.sin(rmax / two_R)) ** 2
+
+    # Progress reporting
+    n_active = int(np.sum(mask_bool))
+    progress_interval = max(n_active // 10, 1)
+    cells_processed = 0
+
+    for i in range(n_cells):
+
+        if not mask_list[i]:
             continue
-        neighbors = np.array(neighbors)
-        neighbors = neighbors[mask_bool[neighbors]]
-        row_indices.extend([i] * len(neighbors))
-        col_indices.extend(neighbors)
-        # Compute great-circle distances in km
-        d_xyz = xyz[i] - xyz[neighbors]
-        # Chord length
-        chord = np.linalg.norm(d_xyz, axis=1)
-        # Convert chord length to arc length (distance on sphere)
-        arc = 2 * R_earth * np.arcsin(np.clip(chord / (2 * R_earth), 0, 1))
+
+        if coastline_masking:
+            # Only apply smoothing to cells adjacent to the coastline
+            if not coastline_mask_bool[i]:
+                row_indices.append(i)
+                col_indices.append(i)
+                data.append(1.0)
+                cells_processed += 1
+                if cells_processed % progress_interval == 0:
+                    print(
+                        f"  smoothing weights: {100 * cells_processed // n_active}% ({cells_processed}/{n_active} cells)"
+                    )
+                continue
+
+        # Cache origin xyz for crow's-fly distance checks
+        xi = xyz_x[i]
+        yi = xyz_y[i]
+        zi = xyz_z[i]
+
+        # BFS with crow's-fly cutoff (circular region) and chord path distance for weights.
+        # For adjacent grid cells, chord ≈ arc distance (error < 0.03% per hop at 1° resolution).
+        # q entries: (cell_index, cumulative_chord_path_distance)
+        q = deque([(i, 0.0)])
+        discovered = {i: 0.0}  # cell -> shortest chord path distance from origin
+        nbr_indices = [i]
+        nbr_path_dist = [0.0]
+        while q:
+            current, current_dist = q.popleft()
+
+            # Iterate over precomputed adjacency (8-connectivity)
+            start = adj_offset[current]
+            end = adj_offset[current + 1]
+            cx = xyz_x[current]
+            cy = xyz_y[current]
+            cz = xyz_z[current]
+            for j in range(start, end):
+                neighbor = adj_flat[j]
+                if neighbor not in discovered and mask_list[neighbor]:
+                    nx_ = xyz_x[neighbor]
+                    ny_ = xyz_y[neighbor]
+                    nz_ = xyz_z[neighbor]
+                    # Crow's-fly distance from origin for BFS cutoff (circular)
+                    dx = xi - nx_
+                    dy = yi - ny_
+                    dz = zi - nz_
+                    if dx * dx + dy * dy + dz * dz <= chord_rmax_sq:
+                        # One-hop chord distance (≈ arc for adjacent cells)
+                        hx = cx - nx_
+                        hy = cy - ny_
+                        hz = cz - nz_
+                        path_dist = current_dist + sqrt(hx * hx + hy * hy + hz * hz)
+                        discovered[neighbor] = path_dist
+                        q.append((neighbor, path_dist))
+                        nbr_indices.append(neighbor)
+                        nbr_path_dist.append(path_dist)
+
+        if len(nbr_indices) == 0:
+            row_indices.append(i)
+            col_indices.append(i)
+            data.append(1.0)
+            cells_processed += 1
+            if cells_processed % progress_interval == 0:
+                print(
+                    f"  smoothing weights: {100 * cells_processed // n_active}% ({cells_processed}/{n_active} cells)"
+                )
+            continue
+
+        # Compute weights from path distances (topology-aware)
+        neighbor_idx = np.array(nbr_indices, dtype=np.int64)
+        arc = np.array(nbr_path_dist)
         weights_data = np.exp(-arc / fold)
-        # Normalize by area
-        weights_data /= np.sum(weights_data * (areas[neighbors] / areas[i]))
+        weights_data /= np.sum(weights_data * (areas[neighbor_idx] / areas[i]))
+
+        row_indices.extend(neighbor_idx)
+        col_indices.extend([i] * len(nbr_indices))
         data.extend(weights_data)
 
-    weights = coo_matrix(
+        cells_processed += 1
+        if cells_processed % progress_interval == 0:
+            print(
+                f"  smoothing weights: {100 * cells_processed // n_active}% ({cells_processed}/{n_active} cells)"
+            )
+
+    weights = csr_matrix(
         (data, (row_indices, col_indices)), shape=(len(coords), len(coords))
     )
     return weights
@@ -834,7 +1055,12 @@ def get_smoothed_map_filepath(mapping_file_prefix, output_dir, rmax, fold):
 
 
 def gen_rof_maps(
-    rof_mesh_path, ocn_mesh_path, output_dir, mapping_file_prefix, rmax=None, fold=None
+    rof_mesh_path,
+    ocn_mesh_path,
+    output_dir,
+    mapping_file_prefix,
+    rmax=None,
+    fold=None,
 ):
     """Generate (1) nearest neighbor and (2) smoothed nearest neighbor mapping files
     from a runoff mesh to an ocean mesh.
@@ -883,6 +1109,7 @@ def gen_rof_maps(
         mapping_file=nn_map_filepath,
         method="nearest_d2s",
         area_normalization=True,
+        coastline_masking=True,
     )
 
     print(f"  Generated nearest mapping file in {(t1:=time()) - t0:.2f} seconds at:")
@@ -910,9 +1137,7 @@ def gen_rof_maps(
         ocn_mesh = xr.open_dataset(ocn_mesh_path)
 
         sw = compute_smoothing_weights(
-            mesh_ds=ocn_mesh,
-            rmax=rmax,
-            fold=fold,
+            mesh_ds=ocn_mesh, rmax=rmax, fold=fold, coastline_masking=True
         )
 
         # mesh dimensions
@@ -927,11 +1152,11 @@ def gen_rof_maps(
             shape=(ocn_nx * ocn_ny, rof_nx * rof_ny),
         )
 
-        # Apply smoothing by multiplying (transpose of) S_coo and smoothing weights (and taking transpose again):
-        S_smooth = S_coo.transpose().dot(sw).transpose()
+        # Apply smoothing to the mapping weights:
+        S_smooth = sw.dot(S_coo)
         assert isinstance(
-            S_smooth, csc_matrix
-        ), "S_smooth should be a csc_matrix after multiplication"
+            S_smooth, csr_matrix
+        ), "S_smooth should be a csr_matrix after multiplication"
         S_smooth = S_smooth.tocoo()  # Convert to COO format again
 
         nnsm_map_filepath = get_smoothed_map_filepath(

--- a/mom6_forge/mapping.py
+++ b/mom6_forge/mapping.py
@@ -1054,6 +1054,61 @@ def get_smoothed_map_filepath(mapping_file_prefix, output_dir, rmax, fold):
     return nnsm_map_filepath
 
 
+def _check_runoff_conserved(weights, area_a, area_b, label, rtol=1e-9):
+    """Verify a mapping redistributes runoff without creating or losing any.
+
+    Every source cell generates runoff in proportion to its own area, so for
+    each source cell j the area-weighted total arriving in the ocean must equal
+    that area::
+
+        sum_i S[i, j] * area_b[i] == area_a[j]
+
+    which is one sparse matrix-vector product, ``weights.T @ area_b``. This
+    holds to ~1e-15 in practice for both the nearest-neighbor and the smoothed
+    map -- smoothing moves runoff around but must not change how much there is.
+
+    Source cells that map nowhere at all are reported but not treated as an
+    error: a mesh may legitimately contain cells with no reachable ocean
+    neighbor, and the weights alone cannot distinguish those from cells whose
+    runoff was dropped by mistake.
+
+    Parameters
+    ----------
+    weights : scipy.sparse matrix, shape (n_b, n_a)
+        Mapping weights, destination cells by source cells.
+    area_a, area_b : np.ndarray
+        Source and destination cell areas.
+
+    Raises
+    ------
+    ValueError
+        If a mapped source cell's runoff is not conserved to within `rtol`
+        (naming the worst offender), or if nothing is mapped at all.
+    """
+    received = np.asarray(weights.T.dot(area_b)).ravel()
+
+    active = received > 0
+    if not active.any():
+        raise ValueError(f"{label} map maps no runoff at all.")
+
+    err = np.abs(received[active] / area_a[active] - 1.0)
+    worst = float(err.max())
+    if worst > rtol:
+        cell = int(np.flatnonzero(active)[np.argmax(err)])
+        raise ValueError(
+            f"{label} map does not conserve runoff. Source cell {cell} has area "
+            f"{area_a[cell]:.6e} but {received[cell]:.6e} reaches the ocean "
+            f"(relative error {worst:.3e}, tolerance {rtol:.0e})."
+        )
+
+    unmapped = int(area_a.size - active.sum())
+    note = f", {unmapped:,} map nowhere" if unmapped else ""
+    print(
+        f"  Runoff conserved to {worst:.1e} across "
+        f"{int(active.sum()):,} source cells{note}."
+    )
+
+
 def gen_rof_maps(
     rof_mesh_path,
     ocn_mesh_path,
@@ -1115,6 +1170,19 @@ def gen_rof_maps(
     print(f"  Generated nearest mapping file in {(t1:=time()) - t0:.2f} seconds at:")
     print(f"  {nn_map_filepath}")
 
+    nn_map = xr.open_dataset(nn_map_filepath)
+    rof_nx, rof_ny = len(nn_map.ni_a), len(nn_map.nj_a)
+    ocn_nx, ocn_ny = len(nn_map.ni_b), len(nn_map.nj_b)
+    area_a = nn_map["area_a"].data
+    area_b = nn_map["area_b"].data
+
+    # Sparse form of the nearest-neighbor weights, reused below for smoothing.
+    S_coo = coo_matrix(
+        (nn_map.S.data, (nn_map.row.data - 1, nn_map.col.data - 1)),
+        shape=(ocn_nx * ocn_ny, rof_nx * rof_ny),
+    )
+    _check_runoff_conserved(S_coo, area_a, area_b, "nearest neighbor")
+
     # Compute and apply smoothing weights
     if rmax is not None:
 
@@ -1124,7 +1192,6 @@ def gen_rof_maps(
         )
         print(f"  rmax = {rmax} km, fold = {fold} km")
 
-        nn_map = xr.open_dataset(nn_map_filepath)
         avg_dst_res_km = get_avg_resolution_km(ocn_mesh_path)
         if rmax > avg_dst_res_km * 10:
             print(
@@ -1140,23 +1207,12 @@ def gen_rof_maps(
             mesh_ds=ocn_mesh, rmax=rmax, fold=fold, coastline_masking=True
         )
 
-        # mesh dimensions
-        rof_nx = len(nn_map.ni_a)
-        rof_ny = len(nn_map.nj_a)
-        ocn_nx = len(nn_map.ni_b)
-        ocn_ny = len(nn_map.nj_b)
-
-        # Create a COO matrix of the mapping weights
-        S_coo = coo_matrix(
-            (nn_map.S.data, (nn_map.row.data - 1, nn_map.col.data - 1)),
-            shape=(ocn_nx * ocn_ny, rof_nx * rof_ny),
-        )
-
         # Apply smoothing to the mapping weights:
         S_smooth = sw.dot(S_coo)
         assert isinstance(
             S_smooth, csr_matrix
         ), "S_smooth should be a csr_matrix after multiplication"
+        _check_runoff_conserved(S_smooth, area_a, area_b, "smoothed")
         S_smooth = S_smooth.tocoo()  # Convert to COO format again
 
         nnsm_map_filepath = get_smoothed_map_filepath(

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -521,3 +521,39 @@ def test_gen_rof_maps_end_to_end(tmp_path):
     )
     nn.close()
     sm.close()
+
+
+# ---------------------------------------------------------------------------
+# _check_runoff_conserved
+# ---------------------------------------------------------------------------
+
+
+def _toy_weights(scale=1.0, drop_last=False):
+    """A conserving (n_b, n_a) mapping; `scale` perturbs one source cell."""
+    area_a = np.array([2.0, 3.0, 5.0])
+    area_b = np.array([1.0, 1.0, 2.0, 4.0])
+    row = col = np.arange(3)  # each source cell -> one destination cell
+    S = area_a[col] / area_b[row]
+    S[0] *= scale
+    if drop_last:  # source cell 2 maps nowhere
+        row, col, S = row[:-1], col[:-1], S[:-1]
+    return sp.coo_matrix((S, (row, col)), shape=(4, 3)), area_a, area_b
+
+
+def test_check_runoff_conserved(capsys):
+    """Conserving maps pass, missing runoff and empty maps raise, and cells
+    that map nowhere are reported rather than treated as failures."""
+    mapping._check_runoff_conserved(*_toy_weights(), "toy")
+
+    with pytest.raises(ValueError, match="does not conserve runoff"):
+        mapping._check_runoff_conserved(*_toy_weights(scale=0.99), "toy")
+
+    _, area_a, area_b = _toy_weights()
+    with pytest.raises(ValueError, match="maps no runoff at all"):
+        mapping._check_runoff_conserved(sp.coo_matrix((4, 3)), area_a, area_b, "toy")
+
+    # Real meshes have unmapped cells -- glo -> tx0.1 drops two polar rows --
+    # so this must be visible without being fatal.
+    capsys.readouterr()
+    mapping._check_runoff_conserved(*_toy_weights(drop_last=True), "toy")
+    assert "1 map nowhere" in capsys.readouterr().out

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -14,6 +14,9 @@ from mom6_forge.mapping import (
 )
 from mom6_forge._supergrid import haversine
 from mom6_forge.grid import Grid
+from mom6_forge import mapping
+
+from utils import fetch_inputdata
 
 
 def make_synthetic_grids():
@@ -402,3 +405,119 @@ def test_write_mapping_file_uses_shape_lookup_not_full_reconstruction(
     ds = xr.open_dataset(out_path)
     assert list(ds["src_grid_dims"].values) == [3, 2]
     assert list(ds["dst_grid_dims"].values) == [2, 2]
+
+
+# ---------------------------------------------------------------------------
+# flatten_to_mesh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field_2d, expected",
+    [
+        (np.array([[1, 2, 3], [4, 5, 6]]), [1, 2, 3, 4, 5, 6]),
+        (
+            xr.DataArray(np.array([[10, 20], [30, 40]]), dims=("nlat", "nlon")),
+            [10, 20, 30, 40],
+        ),
+    ],
+)
+def test_flatten_to_mesh(field_2d, expected):
+    """Row-major (C) ordering, for numpy and DataArray input alike."""
+    result = mapping.flatten_to_mesh(field_2d)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, expected)
+
+
+# ---------------------------------------------------------------------------
+# grid_from_esmf_mesh / flatten_to_mesh roundtrip  (integration, real mesh)
+# ---------------------------------------------------------------------------
+
+
+def test_grid_from_esmf_mesh_flatten_to_mesh_mask_roundtrip():
+    """grid_from_esmf_mesh followed by flatten_to_mesh must recover the
+    original elementMask exactly."""
+    mesh = xr.open_dataset(fetch_inputdata("share/meshes/gx1v7_151008_ESMFmesh.nc"))
+
+    original_mask_1d = mesh["elementMask"].values  # shape (n_elements,)
+
+    # 1D -> 2D
+    grid_2d = mapping.grid_from_esmf_mesh(mesh)
+    mask_2d = grid_2d["mask"]  # xr.DataArray, shape (ny, nx)
+
+    # 2D -> 1D using the standardized helper
+    recovered_mask_1d = mapping.flatten_to_mesh(mask_2d)
+
+    assert recovered_mask_1d.shape == original_mask_1d.shape, (
+        f"Shape mismatch: got {recovered_mask_1d.shape}, "
+        f"expected {original_mask_1d.shape}"
+    )
+    np.testing.assert_array_equal(
+        recovered_mask_1d,
+        original_mask_1d,
+        err_msg="Roundtrip 1D->2D->1D changed elementMask values",
+    )
+
+
+# ---------------------------------------------------------------------------
+# gen_rof_maps end-to-end  (integration, real meshes)
+# ---------------------------------------------------------------------------
+
+
+def test_gen_rof_maps_end_to_end(tmp_path):
+    """Full runoff mapping pipeline on rx1 -> gx1v7.
+
+    Covers generate_ESMF_map_via_xesmf with coastline masking,
+    compute_smoothing_weights (topography-aware BFS) and write_mapping_file.
+    """
+    rof_mesh = fetch_inputdata("share/meshes/rx1_nomask_181022_ESMFmesh.nc")
+    ocn_mesh = fetch_inputdata("share/meshes/gx1v7_151008_ESMFmesh.nc")
+    mapping.gen_rof_maps(
+        rof_mesh, ocn_mesh, tmp_path, "rx1_to_g17", rmax=500.0, fold=500.0
+    )
+
+    nn = xr.open_dataset(tmp_path / "rx1_to_g17_nn.nc")
+    sm = xr.open_dataset(tmp_path / "rx1_to_g17_r500_f500_nnsm.nc")
+    n_dst = int(np.prod(nn["dst_grid_dims"].values))
+    n_src = int(np.prod(nn["src_grid_dims"].values))
+
+    for ds, label in ((nn, "nearest neighbor"), (sm, "smoothed")):
+        row, col, S = ds["row"].values, ds["col"].values, ds["S"].values
+        # Mapping files are 1-based and must stay inside the grids.
+        assert row.min() >= 1 and row.max() <= n_dst, label
+        assert col.min() >= 1 and col.max() <= n_src, label
+        assert np.all(np.isfinite(S)) and np.all(S >= 0.0), label
+
+    # Coastline masking means the nearest-neighbor map may only target ocean
+    # cells adjacent to the coast.
+    ocn = xr.open_dataset(ocn_mesh)
+    coastal = mapping.flatten_to_mesh(
+        mapping.extract_coastline_mask(mapping.grid_from_esmf_mesh(ocn)) == 1
+    ).astype(bool)
+    ocn.close()
+    assert coastal[nn["row"].values - 1].all(), "nn map targets a non-coastal cell"
+
+    # Smoothing spreads each runoff cell over a neighborhood...
+    assert sm["S"].size > nn["S"].size
+
+    # ...but must not create or destroy any runoff: per source cell, the
+    # area-weighted total is unchanged.
+    area_b = nn["area_b"].values
+
+    def totals(ds):
+        return np.bincount(
+            ds["col"].values - 1,
+            weights=ds["S"].values * area_b[ds["row"].values - 1],
+            minlength=n_src,
+        )
+
+    tot_nn, tot_sm = totals(nn), totals(sm)
+    active = tot_nn > 0
+    np.testing.assert_allclose(
+        tot_sm[active],
+        tot_nn[active],
+        rtol=1e-10,
+        err_msg="smoothing did not conserve area-weighted runoff",
+    )
+    nn.close()
+    sm.close()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,91 @@
 """Functions that are used in tests."""
 
+import hashlib
+import os
+import shutil
 import socket
+import urllib.request
+from pathlib import Path
 
 
 def on_cisl_machine():
     """Return True if the current machine is a CISL machine, False otherwise."""
     fqdn = socket.getfqdn()
     return "hpc.ucar.edu" in fqdn
+
+
+# ---------------------------------------------------------------------------
+# CESM input data
+# ---------------------------------------------------------------------------
+
+CESM_INPUTDATA_URL = "https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata"
+GLADE_INPUTDATA = Path("/glade/campaign/cesm/cesmdata/inputdata")
+
+# Files the test suite fetches on demand, keyed by path relative to the CESM
+# input data root. Checksums guard against truncated or corrupted downloads;
+# regenerate with `shasum -a 256` if a file is ever revised.
+INPUTDATA_FILES = {
+    "share/meshes/gx1v7_151008_ESMFmesh.nc": (
+        "b1b892dfa5da00447c35b58a5bc3a35913e6eb1330b48ae46c2e8bcb88a3c641"
+    ),
+    "share/meshes/rx1_nomask_181022_ESMFmesh.nc": (
+        "e67e140e6df410d3ca2b2a574d82959433a1bfabad464e71240370f83f0c41d4"
+    ),
+}
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fetch_inputdata(relpath):
+    """Return a local path to a CESM input data file, downloading if needed.
+
+    Looks in $CESMDATAROOT, then GLADE when on a CISL machine, then a local
+    cache ($MOM6_FORGE_TEST_DATA, else ~/.cache/mom6_forge/inputdata),
+    downloading on a miss. Raises rather than skipping if the file cannot be
+    obtained, so missing coverage is never silent.
+    """
+    expected = INPUTDATA_FILES[relpath]
+
+    root = os.environ.get("CESMDATAROOT")
+    if root and (Path(root) / relpath).exists():
+        return Path(root) / relpath
+    if on_cisl_machine() and (GLADE_INPUTDATA / relpath).exists():
+        return GLADE_INPUTDATA / relpath
+
+    cache = Path(
+        os.environ.get("MOM6_FORGE_TEST_DATA")
+        or Path.home() / ".cache" / "mom6_forge" / "inputdata"
+    )
+    dest = cache / relpath
+    if dest.exists():
+        if _sha256(dest) == expected:
+            return dest
+        dest.unlink()  # corrupt or stale; re-fetch
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    url = f"{CESM_INPUTDATA_URL}/{relpath}"
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        with urllib.request.urlopen(url, timeout=120) as resp, open(tmp, "wb") as out:
+            shutil.copyfileobj(resp, out)
+    except Exception as exc:  # network, DNS, HTTP error, ...
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"Could not download {url}. Set CESMDATAROOT to an existing input "
+            f"data tree, or MOM6_FORGE_TEST_DATA to a writable cache directory."
+        ) from exc
+
+    actual = _sha256(tmp)
+    if actual != expected:
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"Checksum mismatch for {url}\n  expected {expected}\n  got      {actual}"
+        )
+    tmp.rename(dest)
+    return dest


### PR DESCRIPTION
Smooths runoff mapping weights along coastal topology instead of radially, and make generating the maps efficient at high resolution.

## Changes
 - generate_ESMF_map_via_xesmf gains coastline_masking, so nearest-neighbor mapping targets only ocean cells adjacent to the coast.
 - compute_smoothing_weights walks 8-connectivity through ocean cells (BFS), accumulating distance hop by hop, instead of a KD-tree ball query. Land is a barrier, so runoff no longer smears across peninsulas and isthmuses. 
 - gen_rof_maps verifies both maps conserve runoff before finishing.

## New performance:

JRA rof mesh mapped to various ocn grids:

| ocn grid | main | + algorithm | + perf work | total |
|----------|-------:|-----------:|-----------:|------:|
| gx1v7 (500 km)  |  14.68s |   9.86s |  1.80s |  8.2x |
| tx0.25 (100 km) |  86.69s |  23.71s |  5.48s | 15.8x |
| tx0.1 (20 km)   | 214.41s |  81.42s | 12.85s | 16.7x |
| **total**       | **315.78s** | **114.99s** | **20.13s** | **15.7x** |

The algorithmic changes account for 2.7x: coastline masking restricts smoothing to coastal cells, and the BFS replaces a query_ball_tree over the whole mesh. The remaining 5.7x is from vectorizing the neighbor adjacency and vertex-coordinate construction, caching cell areas per mesh file rather than recomputing them five times per call, and writing  NETCDF4_CLASSIC instead of netCDF3.

## File format: 
Mapping files are now written as NETCDF4_CLASSIC rather than 64-bit offset. netCDF3 cannot store a non-final variable of 4 GiB or more, which a JRA -> tx0.25 map exceeds at 1.76 billion weights. NETCDF4_CLASSIC has no such limit and is faster to write at every size. CESM reads these files only through ESMF_FieldSMMStore (cmeps/mediator/med_map_mod.F90); ESMF 8.9.1, the version Derecho loads, reads both formats, verified on Casper. The netCDF-4 refusal in the old SVN rimport went away with the new inputdata tooling, which has published netCDF-4 runoff mapping files since October 2025.